### PR TITLE
chore: adding configurations for lightpush, filter and store

### DIFF
--- a/waku/nwaku.go
+++ b/waku/nwaku.go
@@ -327,23 +327,37 @@ import (
 const requestTimeout = 30 * time.Second
 
 type WakuConfig struct {
-	Host                 string   `json:"host,omitempty"`
-	Port                 int      `json:"port,omitempty"`
-	NodeKey              string   `json:"key,omitempty"`
-	EnableRelay          bool     `json:"relay"`
-	LogLevel             string   `json:"logLevel"`
-	DnsDiscovery         bool     `json:"dnsDiscovery,omitempty"`
-	DnsDiscoveryUrl      string   `json:"dnsDiscoveryUrl,omitempty"`
-	MaxMessageSize       string   `json:"maxMessageSize,omitempty"`
-	Staticnodes          []string `json:"staticnodes,omitempty"`
-	Discv5BootstrapNodes []string `json:"discv5BootstrapNodes,omitempty"`
-	Discv5Discovery      bool     `json:"discv5Discovery,omitempty"`
-	Discv5UdpPort        uint16   `json:"discv5UdpPort,omitempty"`
-	ClusterID            uint16   `json:"clusterId,omitempty"`
-	Shards               []uint16 `json:"shards,omitempty"`
-	PeerExchange         bool     `json:"peerExchange,omitempty"`
-	PeerExchangeNode     string   `json:"peerExchangeNode,omitempty"`
-	TcpPort              uint16   `json:"tcpPort,omitempty"`
+	Host                        string   `json:"host,omitempty"`
+	Port                        int      `json:"port,omitempty"`
+	Nodekey                     string   `json:"nodekey,omitempty"`
+	Relay                       bool     `json:"relay,omitempty"`
+	Store                       bool     `json:"store,omitempty"`
+	Storenode                   string   `json:"storenode,omitempty"`
+	StoreMessageRetentionPolicy string   `json:"storeMessageRetentionPolicy,omitempty"`
+	StoreMessageDbUrl           string   `json:"storeMessageDbUrl,omitempty"`
+	StoreMessageDbVacuum        bool     `json:"storeMessageDbVacuum,omitempty"`
+	StoreMaxNumDbConnections    int      `json:"storeMaxNumDbConnections,omitempty"`
+	StoreResume                 bool     `json:"storeResume,omitempty"`
+	Filter                      bool     `json:"filter,omitempty"`
+	Filternode                  string   `json:"filternode,omitempty"`
+	FilterSubscriptionTimeout   int64    `json:"filterSubscriptionTimeout,omitempty"`
+	FilterMaxPeersToServe       uint32   `json:"filterMaxPeersToServe,omitempty"`
+	FilterMaxCriteria           uint32   `json:"filterMaxCriteria,omitempty"`
+	Lightpush                   bool     `json:"lightpush,omitempty"`
+	LightpushNode               string   `json:"lightpushnode,omitempty"`
+	LogLevel                    string   `json:"logLevel,omitempty"`
+	DnsDiscovery                bool     `json:"dnsDiscovery,omitempty"`
+	DnsDiscoveryUrl             string   `json:"dnsDiscoveryUrl,omitempty"`
+	MaxMessageSize              string   `json:"maxMessageSize,omitempty"`
+	Staticnodes                 []string `json:"staticnodes,omitempty"`
+	Discv5BootstrapNodes        []string `json:"discv5BootstrapNodes,omitempty"`
+	Discv5Discovery             bool     `json:"discv5Discovery,omitempty"`
+	Discv5UdpPort               uint16   `json:"discv5UdpPort,omitempty"`
+	ClusterID                   uint16   `json:"clusterId,omitempty"`
+	Shards                      []uint16 `json:"shards,omitempty"`
+	PeerExchange                bool     `json:"peerExchange,omitempty"`
+	PeerExchangeNode            string   `json:"peerExchangeNode,omitempty"`
+	TcpPort                     uint16   `json:"tcpPort,omitempty"`
 }
 
 // Waku represents a dark communication interface through the Ethereum

--- a/waku/nwaku_test.go
+++ b/waku/nwaku_test.go
@@ -35,8 +35,8 @@ func TestBasicWaku(t *testing.T) {
 
 	nwakuConfig := WakuConfig{
 		Port:            30303,
-		NodeKey:         "11d0dcea28e86f81937a3bd1163473c7fbc0a0db54fd72914849bc47bdf78710",
-		EnableRelay:     true,
+		Nodekey:         "11d0dcea28e86f81937a3bd1163473c7fbc0a0db54fd72914849bc47bdf78710",
+		Relay:           true,
 		LogLevel:        "DEBUG",
 		DnsDiscoveryUrl: "enrtree://AMOJVZX4V6EXP7NTJPMAYJYST2QP6AJXYW76IU6VGJS7UVSNDYZG4@boot.prod.status.nodes.status.im",
 		DnsDiscovery:    true,
@@ -185,7 +185,7 @@ func TestPeerExchange(t *testing.T) {
 
 	// start node that will be discovered by PeerExchange
 	discV5NodeWakuConfig := WakuConfig{
-		EnableRelay:     true,
+		Relay:           true,
 		LogLevel:        "DEBUG",
 		Discv5Discovery: true,
 		ClusterID:       16,
@@ -209,7 +209,7 @@ func TestPeerExchange(t *testing.T) {
 
 	// start node which serves as PeerExchange server
 	pxServerWakuConfig := WakuConfig{
-		EnableRelay:          true,
+		Relay:                true,
 		LogLevel:             "DEBUG",
 		Discv5Discovery:      true,
 		ClusterID:            16,
@@ -254,7 +254,7 @@ func TestPeerExchange(t *testing.T) {
 
 	// start light node which uses PeerExchange to discover peers
 	pxClientWakuConfig := WakuConfig{
-		EnableRelay:      false,
+		Relay:            false,
 		LogLevel:         "DEBUG",
 		Discv5Discovery:  false,
 		ClusterID:        16,
@@ -315,7 +315,7 @@ func TestDnsDiscover(t *testing.T) {
 
 	nameserver := "8.8.8.8"
 	nodeWakuConfig := WakuConfig{
-		EnableRelay:   true,
+		Relay:         true,
 		LogLevel:      "DEBUG",
 		ClusterID:     16,
 		Shards:        []uint16{64},
@@ -343,7 +343,7 @@ func TestDial(t *testing.T) {
 
 	// start node that will initiate the dial
 	dialerNodeWakuConfig := WakuConfig{
-		EnableRelay:     true,
+		Relay:           true,
 		LogLevel:        "DEBUG",
 		Discv5Discovery: false,
 		ClusterID:       16,
@@ -359,7 +359,7 @@ func TestDial(t *testing.T) {
 
 	// start node that will receive the dial
 	receiverNodeWakuConfig := WakuConfig{
-		EnableRelay:     true,
+		Relay:           true,
 		LogLevel:        "DEBUG",
 		Discv5Discovery: false,
 		ClusterID:       16,


### PR DESCRIPTION
Adding all configurations related to the setup of Lightpush, Filter and Store protocols.

In addition, changed the name of the `EnableRelay` and `NodeKey` fields in `WakuConfig` for `Relay` and `Nodekey` respectively.

That was done for consistency, so all the fields in `WakuConfig` match 1 to 1 to the names in https://github.com/waku-org/nwaku/blob/master/waku/factory/external_config.nim with the only difference that in `WakuConfig` the first letter of each field name is capitalized. 