### PR TITLE
chore: code cleanup

### DIFF
--- a/waku/nwaku.go
+++ b/waku/nwaku.go
@@ -433,7 +433,6 @@ type WakuNode struct {
 	wakuCtx         unsafe.Pointer
 	wakuCfg         *WakuConfig
 	logger          *zap.Logger
-	cancel          context.CancelFunc
 	MsgChan         chan common.Envelope
 	TopicHealthChan chan topicHealth
 }
@@ -442,6 +441,7 @@ func newWakuNode(config *WakuConfig, logger *zap.Logger) (*WakuNode, error) {
 
 	n := &WakuNode{
 		wakuCfg: config,
+		logger:  logger,
 	}
 
 	wg := sync.WaitGroup{}
@@ -469,7 +469,6 @@ func newWakuNode(config *WakuConfig, logger *zap.Logger) (*WakuNode, error) {
 
 	n.MsgChan = make(chan common.Envelope, MsgChanBufferSize)
 	n.TopicHealthChan = make(chan topicHealth, TopicHealthChanBufferSize)
-	n.logger = logger.Named("nwaku")
 
 	// Notice that the events for self node are handled by the 'MyEventCallback' method
 	C.cGoWakuSetEventCallback(n.wakuCtx)
@@ -544,7 +543,6 @@ func (n *WakuNode) OnEvent(eventStr string) {
 }
 
 func (n *WakuNode) parseMessageEvent(eventStr string) {
-	fmt.Println("----------- got message event: ", eventStr)
 	envelope, err := common.NewEnvelope(eventStr)
 	if err != nil {
 		n.logger.Error("could not parse message", zap.Error(err))

--- a/waku/nwaku.go
+++ b/waku/nwaku.go
@@ -431,17 +431,17 @@ func GoCallback(ret C.int, msg *C.char, len C.size_t, resp unsafe.Pointer) {
 // WakuNode represents an instance of an nwaku node
 type WakuNode struct {
 	wakuCtx         unsafe.Pointer
-	wakuCfg         *WakuConfig
+	config          *WakuConfig
 	logger          *zap.Logger
 	MsgChan         chan common.Envelope
 	TopicHealthChan chan topicHealth
 }
 
-func newWakuNode(config *WakuConfig, logger *zap.Logger) (*WakuNode, error) {
+func NewWakuNode(config *WakuConfig, logger *zap.Logger) (*WakuNode, error) {
 
 	n := &WakuNode{
-		wakuCfg: config,
-		logger:  logger,
+		config: config,
+		logger: logger,
 	}
 
 	wg := sync.WaitGroup{}

--- a/waku/nwaku.go
+++ b/waku/nwaku.go
@@ -430,8 +430,8 @@ func GoCallback(ret C.int, msg *C.char, len C.size_t, resp unsafe.Pointer) {
 
 // WakuNode represents an instance of an nwaku node
 type WakuNode struct {
-	ptr             unsafe.Pointer
-	config          *WakuConfig
+	wakuCtx         unsafe.Pointer
+	wakuCfg         *WakuConfig
 	logger          *zap.Logger
 	MsgChan         chan common.Envelope
 	TopicHealthChan chan topicHealth
@@ -440,8 +440,8 @@ type WakuNode struct {
 func newWakuNode(config *WakuConfig, logger *zap.Logger) (*WakuNode, error) {
 
 	n := &WakuNode{
-		config: config,
-		logger: logger,
+		wakuCfg: config,
+		logger:  logger,
 	}
 
 	wg := sync.WaitGroup{}
@@ -464,14 +464,14 @@ func newWakuNode(config *WakuConfig, logger *zap.Logger) (*WakuNode, error) {
 	}
 
 	wg.Add(1)
-	n.ptr = C.cGoWakuNew(cJsonConfig, resp)
+	n.wakuCtx = C.cGoWakuNew(cJsonConfig, resp)
 	wg.Wait()
 
 	n.MsgChan = make(chan common.Envelope, MsgChanBufferSize)
 	n.TopicHealthChan = make(chan topicHealth, TopicHealthChanBufferSize)
 
 	// Notice that the events for self node are handled by the 'MyEventCallback' method
-	C.cGoWakuSetEventCallback(n.ptr)
+	C.cGoWakuSetEventCallback(n.wakuCtx)
 	registerNode(n)
 
 	return n, nil
@@ -490,14 +490,14 @@ func init() {
 }
 
 func registerNode(node *WakuNode) {
-	_, ok := nodeRegistry[node.ptr]
+	_, ok := nodeRegistry[node.wakuCtx]
 	if !ok {
-		nodeRegistry[node.ptr] = node
+		nodeRegistry[node.wakuCtx] = node
 	}
 }
 
 func unregisterNode(node *WakuNode) {
-	delete(nodeRegistry, node.ptr)
+	delete(nodeRegistry, node.wakuCtx)
 }
 
 //export globalEventCallback
@@ -576,7 +576,7 @@ func (n *WakuNode) GetNumConnectedRelayPeers(optPubsubTopic ...string) (int, err
 	var cPubsubTopic = C.CString(pubsubTopic)
 	defer C.free(unsafe.Pointer(cPubsubTopic))
 
-	C.cGoWakuGetNumConnectedRelayPeers(n.ptr, cPubsubTopic, resp)
+	C.cGoWakuGetNumConnectedRelayPeers(n.wakuCtx, cPubsubTopic, resp)
 
 	if C.getRet(resp) == C.RET_OK {
 		numPeersStr := C.GoStringN(C.getMyCharPtr(resp), C.int(C.getMyCharLen(resp)))
@@ -601,7 +601,7 @@ func (n *WakuNode) DisconnectPeerByID(peerID peer.ID) error {
 	defer C.free(unsafe.Pointer(cPeerId))
 
 	wg.Add(1)
-	C.cGoWakuDisconnectPeerById(n.ptr, cPeerId, resp)
+	C.cGoWakuDisconnectPeerById(n.wakuCtx, cPeerId, resp)
 	wg.Wait()
 
 	if C.getRet(resp) == C.RET_OK {
@@ -618,7 +618,7 @@ func (n *WakuNode) GetConnectedPeers() (peer.IDSlice, error) {
 	defer C.freeResp(resp)
 
 	wg.Add(1)
-	C.cGoWakuGetConnectedPeers(n.ptr, resp)
+	C.cGoWakuGetConnectedPeers(n.wakuCtx, resp)
 	wg.Wait()
 
 	if C.getRet(resp) == C.RET_OK {
@@ -656,12 +656,12 @@ func (n *WakuNode) RelaySubscribe(pubsubTopic string) error {
 	defer C.freeResp(resp)
 	defer C.free(unsafe.Pointer(cPubsubTopic))
 
-	if n.ptr == nil {
+	if n.wakuCtx == nil {
 		return errors.New("wakuCtx is nil")
 	}
 
 	wg.Add(1)
-	C.cGoWakuRelaySubscribe(n.ptr, cPubsubTopic, resp)
+	C.cGoWakuRelaySubscribe(n.wakuCtx, cPubsubTopic, resp)
 	wg.Wait()
 
 	if C.getRet(resp) == C.RET_OK {
@@ -687,12 +687,12 @@ func (n *WakuNode) RelayAddProtectedShard(clusterId uint16, shardId uint16, pubk
 	defer C.freeResp(resp)
 	defer C.free(unsafe.Pointer(cPublicKey))
 
-	if n.ptr == nil {
+	if n.wakuCtx == nil {
 		return errors.New("wakuCtx is nil")
 	}
 
 	wg.Add(1)
-	C.cGoWakuRelayAddProtectedShard(n.ptr, C.int(clusterId), C.int(shardId), cPublicKey, resp)
+	C.cGoWakuRelayAddProtectedShard(n.wakuCtx, C.int(clusterId), C.int(shardId), cPublicKey, resp)
 	wg.Wait()
 
 	if C.getRet(resp) == C.RET_OK {
@@ -716,12 +716,12 @@ func (n *WakuNode) RelayUnsubscribe(pubsubTopic string) error {
 	defer C.freeResp(resp)
 	defer C.free(unsafe.Pointer(cPubsubTopic))
 
-	if n.ptr == nil {
+	if n.wakuCtx == nil {
 		return errors.New("wakuCtx is nil")
 	}
 
 	wg.Add(1)
-	C.cGoWakuRelayUnsubscribe(n.ptr, cPubsubTopic, resp)
+	C.cGoWakuRelayUnsubscribe(n.wakuCtx, cPubsubTopic, resp)
 	wg.Wait()
 
 	if C.getRet(resp) == C.RET_OK {
@@ -739,7 +739,7 @@ func (n *WakuNode) PeerExchangeRequest(numPeers uint64) (uint64, error) {
 	defer C.freeResp(resp)
 
 	wg.Add(1)
-	C.cGoWakuPeerExchangeQuery(n.ptr, C.uint64_t(numPeers), resp)
+	C.cGoWakuPeerExchangeQuery(n.wakuCtx, C.uint64_t(numPeers), resp)
 	wg.Wait()
 	if C.getRet(resp) == C.RET_OK {
 		numRecvPeersStr := C.GoStringN(C.getMyCharPtr(resp), C.int(C.getMyCharLen(resp)))
@@ -761,7 +761,7 @@ func (n *WakuNode) StartDiscV5() error {
 	defer C.freeResp(resp)
 
 	wg.Add(1)
-	C.cGoWakuStartDiscV5(n.ptr, resp)
+	C.cGoWakuStartDiscV5(n.wakuCtx, resp)
 	wg.Wait()
 	if C.getRet(resp) == C.RET_OK {
 		return nil
@@ -777,7 +777,7 @@ func (n *WakuNode) StopDiscV5() error {
 	defer C.freeResp(resp)
 
 	wg.Add(1)
-	C.cGoWakuStopDiscV5(n.ptr, resp)
+	C.cGoWakuStopDiscV5(n.wakuCtx, resp)
 	wg.Wait()
 
 	if C.getRet(resp) == C.RET_OK {
@@ -794,7 +794,7 @@ func (n *WakuNode) Version() (string, error) {
 	defer C.freeResp(resp)
 
 	wg.Add(1)
-	C.cGoWakuVersion(n.ptr, resp)
+	C.cGoWakuVersion(n.wakuCtx, resp)
 	wg.Wait()
 
 	if C.getRet(resp) == C.RET_OK {
@@ -831,7 +831,7 @@ func (n *WakuNode) StoreQuery(ctx context.Context, storeRequest *storepb.StoreQu
 	defer C.freeResp(resp)
 
 	wg.Add(1)
-	C.cGoWakuStoreQuery(n.ptr, cJsonQuery, cPeerAddr, C.int(timeoutMs), resp)
+	C.cGoWakuStoreQuery(n.wakuCtx, cJsonQuery, cPeerAddr, C.int(timeoutMs), resp)
 	wg.Wait()
 
 	if C.getRet(resp) == C.RET_OK {
@@ -866,7 +866,7 @@ func (n *WakuNode) RelayPublish(ctx context.Context, message *pb.WakuMessage, pu
 	defer C.free(unsafe.Pointer(msg))
 
 	wg.Add(1)
-	C.cGoWakuRelayPublish(n.ptr, cPubsubTopic, msg, C.int(timeoutMs), resp)
+	C.cGoWakuRelayPublish(n.wakuCtx, cPubsubTopic, msg, C.int(timeoutMs), resp)
 	wg.Wait()
 	if C.getRet(resp) == C.RET_OK {
 		msgHash := C.GoStringN(C.getMyCharPtr(resp), C.int(C.getMyCharLen(resp)))
@@ -892,7 +892,7 @@ func (n *WakuNode) DnsDiscovery(ctx context.Context, enrTreeUrl string, nameDnsS
 
 	timeoutMs := getContextTimeoutMilliseconds(ctx)
 	wg.Add(1)
-	C.cGoWakuDnsDiscovery(n.ptr, cEnrTree, cDnsServer, C.int(timeoutMs), resp)
+	C.cGoWakuDnsDiscovery(n.wakuCtx, cEnrTree, cDnsServer, C.int(timeoutMs), resp)
 	wg.Wait()
 	if C.getRet(resp) == C.RET_OK {
 		var addrsRet []multiaddr.Multiaddr
@@ -927,7 +927,7 @@ func (n *WakuNode) PingPeer(ctx context.Context, peerInfo peer.AddrInfo) (time.D
 
 	timeoutMs := getContextTimeoutMilliseconds(ctx)
 	wg.Add(1)
-	C.cGoWakuPingPeer(n.ptr, cPeerId, C.int(timeoutMs), resp)
+	C.cGoWakuPingPeer(n.wakuCtx, cPeerId, C.int(timeoutMs), resp)
 	wg.Wait()
 	if C.getRet(resp) == C.RET_OK {
 		rttStr := C.GoStringN(C.getMyCharPtr(resp), C.int(C.getMyCharLen(resp)))
@@ -949,7 +949,7 @@ func (n *WakuNode) Start() error {
 	defer C.freeResp(resp)
 
 	wg.Add(1)
-	C.cGoWakuStart(n.ptr, resp)
+	C.cGoWakuStart(n.wakuCtx, resp)
 	wg.Wait()
 	if C.getRet(resp) == C.RET_OK {
 		return nil
@@ -966,7 +966,7 @@ func (n *WakuNode) Stop() error {
 	defer C.freeResp(resp)
 
 	wg.Add(1)
-	C.cGoWakuStop(n.ptr, resp)
+	C.cGoWakuStop(n.wakuCtx, resp)
 	wg.Wait()
 	if C.getRet(resp) == C.RET_OK {
 		unregisterNode(n)
@@ -984,7 +984,7 @@ func (n *WakuNode) Destroy() error {
 	defer C.freeResp(resp)
 
 	wg.Add(1)
-	C.cGoWakuDestroy(n.ptr, resp)
+	C.cGoWakuDestroy(n.wakuCtx, resp)
 	wg.Wait()
 	if C.getRet(resp) == C.RET_OK {
 		return nil
@@ -1001,7 +1001,7 @@ func (n *WakuNode) PeerID() (peer.ID, error) {
 	defer C.freeResp(resp)
 
 	wg.Add(1)
-	C.cGoWakuGetMyPeerId(n.ptr, resp)
+	C.cGoWakuGetMyPeerId(n.wakuCtx, resp)
 	wg.Wait()
 	if C.getRet(resp) == C.RET_OK {
 		peerIdStr := C.GoStringN(C.getMyCharPtr(resp), C.int(C.getMyCharLen(resp)))
@@ -1026,7 +1026,7 @@ func (n *WakuNode) Connect(ctx context.Context, addr multiaddr.Multiaddr) error 
 
 	timeoutMs := getContextTimeoutMilliseconds(ctx)
 	wg.Add(1)
-	C.cGoWakuConnect(n.ptr, cPeerMultiAddr, C.int(timeoutMs), resp)
+	C.cGoWakuConnect(n.wakuCtx, cPeerMultiAddr, C.int(timeoutMs), resp)
 	wg.Wait()
 	if C.getRet(resp) == C.RET_OK {
 		return nil
@@ -1048,7 +1048,7 @@ func (n *WakuNode) DialPeerByID(ctx context.Context, peerID peer.ID, protocol li
 
 	timeoutMs := getContextTimeoutMilliseconds(ctx)
 	wg.Add(1)
-	C.cGoWakuDialPeerById(n.ptr, cPeerId, cProtocol, C.int(timeoutMs), resp)
+	C.cGoWakuDialPeerById(n.wakuCtx, cPeerId, cProtocol, C.int(timeoutMs), resp)
 	wg.Wait()
 	if C.getRet(resp) == C.RET_OK {
 		return nil
@@ -1065,7 +1065,7 @@ func (n *WakuNode) ListenAddresses() ([]multiaddr.Multiaddr, error) {
 	defer C.freeResp(resp)
 
 	wg.Add(1)
-	C.cGoWakuListenAddresses(n.ptr, resp)
+	C.cGoWakuListenAddresses(n.wakuCtx, resp)
 	wg.Wait()
 	if C.getRet(resp) == C.RET_OK {
 		var addrsRet []multiaddr.Multiaddr
@@ -1091,7 +1091,7 @@ func (n *WakuNode) ENR() (*enode.Node, error) {
 	defer C.freeResp(resp)
 
 	wg.Add(1)
-	C.cGoWakuGetMyENR(n.ptr, resp)
+	C.cGoWakuGetMyENR(n.wakuCtx, resp)
 	wg.Wait()
 	if C.getRet(resp) == C.RET_OK {
 		enrStr := C.GoStringN(C.getMyCharPtr(resp), C.int(C.getMyCharLen(resp)))
@@ -1115,7 +1115,7 @@ func (n *WakuNode) GetNumPeersInMesh(pubsubTopic string) (int, error) {
 	defer C.free(unsafe.Pointer(cPubsubTopic))
 
 	wg.Add(1)
-	C.cGoWakuGetNumPeersInMesh(n.ptr, cPubsubTopic, resp)
+	C.cGoWakuGetNumPeersInMesh(n.wakuCtx, cPubsubTopic, resp)
 	wg.Wait()
 	if C.getRet(resp) == C.RET_OK {
 		numPeersStr := C.GoStringN(C.getMyCharPtr(resp), C.int(C.getMyCharLen(resp)))
@@ -1138,7 +1138,7 @@ func (n *WakuNode) GetPeerIDsFromPeerStore() (peer.IDSlice, error) {
 	defer C.freeResp(resp)
 
 	wg.Add(1)
-	C.cGoWakuGetPeerIdsFromPeerStore(n.ptr, resp)
+	C.cGoWakuGetPeerIdsFromPeerStore(n.wakuCtx, resp)
 	wg.Wait()
 	if C.getRet(resp) == C.RET_OK {
 		peersStr := C.GoStringN(C.getMyCharPtr(resp), C.int(C.getMyCharLen(resp)))
@@ -1171,7 +1171,7 @@ func (n *WakuNode) GetPeerIDsByProtocol(protocol libp2pproto.ID) (peer.IDSlice, 
 	defer C.free(unsafe.Pointer(cProtocol))
 
 	wg.Add(1)
-	C.cGoWakuGetPeerIdsByProtocol(n.ptr, cProtocol, resp)
+	C.cGoWakuGetPeerIdsByProtocol(n.wakuCtx, cProtocol, resp)
 	wg.Wait()
 	if C.getRet(resp) == C.RET_OK {
 		peersStr := C.GoStringN(C.getMyCharPtr(resp), C.int(C.getMyCharLen(resp)))
@@ -1208,7 +1208,7 @@ func (n *WakuNode) DialPeer(ctx context.Context, peerAddr multiaddr.Multiaddr, p
 
 	timeoutMs := getContextTimeoutMilliseconds(ctx)
 	wg.Add(1)
-	C.cGoWakuDialPeer(n.ptr, cPeerMultiAddr, cProtocol, C.int(timeoutMs), resp)
+	C.cGoWakuDialPeer(n.wakuCtx, cPeerMultiAddr, cProtocol, C.int(timeoutMs), resp)
 	wg.Wait()
 	if C.getRet(resp) == C.RET_OK {
 		return nil

--- a/waku/nwaku_test.go
+++ b/waku/nwaku_test.go
@@ -53,7 +53,7 @@ func TestBasicWaku(t *testing.T) {
 	storeNodeMa, err := ma.NewMultiaddr(storeNodeInfo.ListenAddresses[0])
 	require.NoError(t, err)
 
-	w, err := newWakuNode(&nwakuConfig, logger.Named("nwaku"))
+	w, err := NewWakuNode(&nwakuConfig, logger.Named("nwaku"))
 	require.NoError(t, err)
 	require.NoError(t, w.Start())
 
@@ -201,7 +201,7 @@ func TestPeerExchange(t *testing.T) {
 		TcpPort:         60010,
 	}
 
-	discV5Node, err := newWakuNode(&discV5NodeWakuConfig, logger.Named("discV5Node"))
+	discV5Node, err := NewWakuNode(&discV5NodeWakuConfig, logger.Named("discV5Node"))
 	require.NoError(t, err)
 	require.NoError(t, discV5Node.Start())
 
@@ -226,7 +226,7 @@ func TestPeerExchange(t *testing.T) {
 		TcpPort:              60011,
 	}
 
-	pxServerNode, err := newWakuNode(&pxServerWakuConfig, logger.Named("pxServerNode"))
+	pxServerNode, err := NewWakuNode(&pxServerWakuConfig, logger.Named("pxServerNode"))
 	require.NoError(t, err)
 	require.NoError(t, pxServerNode.Start())
 
@@ -271,7 +271,7 @@ func TestPeerExchange(t *testing.T) {
 		PeerExchangeNode: serverNodeMa[0].String(),
 	}
 
-	lightNode, err := newWakuNode(&pxClientWakuConfig, logger.Named("lightNode"))
+	lightNode, err := NewWakuNode(&pxClientWakuConfig, logger.Named("lightNode"))
 	require.NoError(t, err)
 	require.NoError(t, lightNode.Start())
 
@@ -329,7 +329,7 @@ func TestDnsDiscover(t *testing.T) {
 		TcpPort:       60020,
 	}
 
-	node, err := newWakuNode(&nodeWakuConfig, logger.Named("node"))
+	node, err := NewWakuNode(&nodeWakuConfig, logger.Named("node"))
 	require.NoError(t, err)
 	require.NoError(t, node.Start())
 	time.Sleep(1 * time.Second)
@@ -359,7 +359,7 @@ func TestDial(t *testing.T) {
 		TcpPort:         60030,
 	}
 
-	dialerNode, err := newWakuNode(&dialerNodeWakuConfig, logger.Named("dialerNode"))
+	dialerNode, err := NewWakuNode(&dialerNodeWakuConfig, logger.Named("dialerNode"))
 	require.NoError(t, err)
 	require.NoError(t, dialerNode.Start())
 
@@ -374,7 +374,7 @@ func TestDial(t *testing.T) {
 		TcpPort:         60031,
 	}
 
-	receiverNode, err := newWakuNode(&receiverNodeWakuConfig, logger.Named("receiverNode"))
+	receiverNode, err := NewWakuNode(&receiverNodeWakuConfig, logger.Named("receiverNode"))
 	require.NoError(t, err)
 	require.NoError(t, receiverNode.Start())
 	receiverMultiaddr, err := receiverNode.ListenAddresses()
@@ -420,7 +420,7 @@ func TestRelay(t *testing.T) {
 		TcpPort:         60040,
 	}
 
-	senderNode, err := newWakuNode(&senderNodeWakuConfig, logger.Named("senderNode"))
+	senderNode, err := NewWakuNode(&senderNodeWakuConfig, logger.Named("senderNode"))
 	require.NoError(t, err)
 	require.NoError(t, senderNode.Start())
 	time.Sleep(1 * time.Second)
@@ -435,7 +435,7 @@ func TestRelay(t *testing.T) {
 		Discv5UdpPort:   9041,
 		TcpPort:         60041,
 	}
-	receiverNode, err := newWakuNode(&receiverNodeWakuConfig, logger.Named("receiverNode"))
+	receiverNode, err := NewWakuNode(&receiverNodeWakuConfig, logger.Named("receiverNode"))
 	require.NoError(t, err)
 	require.NoError(t, receiverNode.Start())
 	time.Sleep(1 * time.Second)
@@ -501,7 +501,7 @@ func TestTopicHealth(t *testing.T) {
 		TcpPort:         60050,
 	}
 
-	node1, err := newWakuNode(&wakuConfig1, logger.Named("node1"))
+	node1, err := NewWakuNode(&wakuConfig1, logger.Named("node1"))
 	require.NoError(t, err)
 	require.NoError(t, node1.Start())
 	time.Sleep(1 * time.Second)
@@ -516,7 +516,7 @@ func TestTopicHealth(t *testing.T) {
 		Discv5UdpPort:   9051,
 		TcpPort:         60051,
 	}
-	node2, err := newWakuNode(&wakuConfig2, logger.Named("node2"))
+	node2, err := NewWakuNode(&wakuConfig2, logger.Named("node2"))
 	require.NoError(t, err)
 	require.NoError(t, node2.Start())
 	time.Sleep(1 * time.Second)

--- a/waku/nwaku_test.go
+++ b/waku/nwaku_test.go
@@ -35,6 +35,9 @@ func TestBasicWaku(t *testing.T) {
 
 	// ctx := context.Background()
 
+	logger, err := zap.NewDevelopment()
+	require.NoError(t, err)
+
 	nwakuConfig := WakuConfig{
 		Nodekey:         "11d0dcea28e86f81937a3bd1163473c7fbc0a0db54fd72914849bc47bdf78710",
 		Relay:           true,
@@ -50,7 +53,7 @@ func TestBasicWaku(t *testing.T) {
 	storeNodeMa, err := ma.NewMultiaddr(storeNodeInfo.ListenAddresses[0])
 	require.NoError(t, err)
 
-	w, err := newWakuNode(&nwakuConfig, nil)
+	w, err := newWakuNode(&nwakuConfig, logger.Named("nwaku"))
 	require.NoError(t, err)
 	require.NoError(t, w.Start())
 


### PR DESCRIPTION
Cleaning up unnecessary parts that were inherited from status-go, mainly:

- The `Waku` type
- Usage of `ctx` and `cancel`
- Unnecessary goroutine