### PR TITLE
chore: using msg hash in hex and adding store test

### DIFF
--- a/waku/common/envelope.go
+++ b/waku/common/envelope.go
@@ -3,7 +3,6 @@ package common
 import (
 	"encoding/json"
 
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
 )
 
@@ -13,13 +12,13 @@ import (
 type Envelope interface {
 	Message() *pb.WakuMessage
 	PubsubTopic() string
-	Hash() pb.MessageHash
+	Hash() MessageHash
 }
 
 type envelopeImpl struct {
 	msg   *pb.WakuMessage
 	topic string
-	hash  pb.MessageHash
+	hash  MessageHash
 }
 
 type tmpWakuMessageJson struct {
@@ -35,7 +34,7 @@ type tmpWakuMessageJson struct {
 type tmpEnvelopeStruct struct {
 	WakuMessage tmpWakuMessageJson `json:"wakuMessage"`
 	PubsubTopic string             `json:"pubsubTopic"`
-	MessageHash string             `json:"messageHash"`
+	MessageHash MessageHash        `json:"messageHash"`
 }
 
 // NewEnvelope creates a new Envelope from a json string generated in nwaku
@@ -46,7 +45,6 @@ func NewEnvelope(jsonEventStr string) (Envelope, error) {
 		return nil, err
 	}
 
-	hash, err := hexutil.Decode(tmpEnvelopeStruct.MessageHash)
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +60,7 @@ func NewEnvelope(jsonEventStr string) (Envelope, error) {
 			RateLimitProof: tmpEnvelopeStruct.WakuMessage.RateLimitProof,
 		},
 		topic: tmpEnvelopeStruct.PubsubTopic,
-		hash:  pb.ToMessageHash(hash),
+		hash:  tmpEnvelopeStruct.MessageHash,
 	}, nil
 }
 
@@ -74,6 +72,6 @@ func (e *envelopeImpl) PubsubTopic() string {
 	return e.topic
 }
 
-func (e *envelopeImpl) Hash() pb.MessageHash {
+func (e *envelopeImpl) Hash() MessageHash {
 	return e.hash
 }

--- a/waku/common/message_hash.go
+++ b/waku/common/message_hash.go
@@ -1,0 +1,38 @@
+package common
+
+import (
+	"encoding/hex"
+	"fmt"
+)
+
+// MessageHash represents an unique identifier for a message within a pubsub topic
+type MessageHash string
+
+func ToMessageHash(val string) (MessageHash, error) {
+	if len(val) == 0 {
+		return "", fmt.Errorf("empty string not allowed")
+	}
+
+	if len(val) < 2 || val[:2] != "0x" {
+		return "", fmt.Errorf("string must start with 0x")
+	}
+
+	// Remove "0x" prefix for hex decoding
+	hexStr := val[2:]
+
+	// Verify the remaining string is valid hex
+	_, err := hex.DecodeString(hexStr)
+	if err != nil {
+		return "", fmt.Errorf("invalid hex string: %v", err)
+	}
+
+	return MessageHash(val), nil
+}
+
+func (h MessageHash) String() string {
+	return string(h)
+}
+
+func (h MessageHash) Bytes() ([]byte, error) {
+	return hex.DecodeString(string(h))
+}

--- a/waku/common/message_hash.go
+++ b/waku/common/message_hash.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"encoding/hex"
+	"errors"
 	"fmt"
 )
 
@@ -10,11 +11,11 @@ type MessageHash string
 
 func ToMessageHash(val string) (MessageHash, error) {
 	if len(val) == 0 {
-		return "", fmt.Errorf("empty string not allowed")
+		return "", errors.New("empty string not allowed")
 	}
 
 	if len(val) < 2 || val[:2] != "0x" {
-		return "", fmt.Errorf("string must start with 0x")
+		return "", errors.New("string must start with 0x")
 	}
 
 	// Remove "0x" prefix for hex decoding

--- a/waku/common/store.go
+++ b/waku/common/store.go
@@ -3,7 +3,7 @@ package common
 type StoreQueryRequest struct {
 	RequestId         string        `json:"request_id"`
 	IncludeData       bool          `json:"include_data"`
-	PubsubTopic       *string       `json:"pubsub_topic,omitempty"`
+	PubsubTopic       string        `json:"pubsub_topic,omitempty"`
 	ContentTopics     []string      `json:"content_topics,omitempty"`
 	TimeStart         *int64        `json:"time_start,omitempty"`
 	TimeEnd           *int64        `json:"time_end,omitempty"`

--- a/waku/common/store.go
+++ b/waku/common/store.go
@@ -1,22 +1,28 @@
 package common
 
 type StoreQueryRequest struct {
-	RequestId         string        `json:"requestId,omitempty"`
-	IncludeData       bool          `json:"includeData,omitempty"`
-	PubsubTopic       *string       `json:"pubsubTopic,omitempty"`
-	ContentTopics     []string      `json:"contentTopics,omitempty"`
-	TimeStart         *int64        `json:"timeStart,omitempty"`
-	TimeEnd           *int64        `json:"timeEnd,omitempty"`
-	MessageHashes     []MessageHash `json:"messageHashes,omitempty"`
-	PaginationCursor  []MessageHash `json:"paginationCursor,omitempty"`
-	PaginationForward bool          `json:"paginationForward,omitempty"`
-	PaginationLimit   *uint64       `json:"paginationLimit,omitempty"`
+	RequestId         string        `json:"request_id"`
+	IncludeData       bool          `json:"include_data"`
+	PubsubTopic       *string       `json:"pubsub_topic,omitempty"`
+	ContentTopics     []string      `json:"content_topics,omitempty"`
+	TimeStart         *int64        `json:"time_start,omitempty"`
+	TimeEnd           *int64        `json:"time_end,omitempty"`
+	MessageHashes     []MessageHash `json:"message_hashes,omitempty"`
+	PaginationCursor  MessageHash   `json:"pagination_cursor,omitempty"`
+	PaginationForward bool          `json:"pagination_forward"`
+	PaginationLimit   *uint64       `json:"pagination_limit,omitempty"`
+}
+
+type storeMessageResponse struct {
+	WakuMessage tmpWakuMessageJson `json:"message"`
+	PubsubTopic string             `json:"pubsubTopic"`
+	MessageHash MessageHash        `json:"messageHash"`
 }
 
 type StoreQueryResponse struct {
-	RequestId        string        `json:"request_id,omitempty"`
-	StatusCode       *uint32       `json:"status_code,omitempty"`
-	StatusDesc       *string       `json:"status_desc,omitempty"`
-	Messages         []*Envelope   `json:"messages,omitempty"`
-	PaginationCursor []MessageHash `json:"pagination_cursor,omitempty"`
+	RequestId        string                 `json:"requestId,omitempty"`
+	StatusCode       *uint32                `json:"statusCode,omitempty"`
+	StatusDesc       string                 `json:"statusDesc,omitempty"`
+	Messages         []storeMessageResponse `json:"messages,omitempty"`
+	PaginationCursor MessageHash            `json:"paginationCursor,omitempty"`
 }

--- a/waku/common/store.go
+++ b/waku/common/store.go
@@ -1,16 +1,16 @@
 package common
 
 type StoreQueryRequest struct {
-	RequestId         string        `json:"request_id"`
-	IncludeData       bool          `json:"include_data"`
-	PubsubTopic       string        `json:"pubsub_topic,omitempty"`
-	ContentTopics     []string      `json:"content_topics,omitempty"`
-	TimeStart         *int64        `json:"time_start,omitempty"`
-	TimeEnd           *int64        `json:"time_end,omitempty"`
-	MessageHashes     []MessageHash `json:"message_hashes,omitempty"`
-	PaginationCursor  MessageHash   `json:"pagination_cursor,omitempty"`
-	PaginationForward bool          `json:"pagination_forward"`
-	PaginationLimit   *uint64       `json:"pagination_limit,omitempty"`
+	RequestId         string         `json:"request_id"`
+	IncludeData       bool           `json:"include_data"`
+	PubsubTopic       string         `json:"pubsub_topic,omitempty"`
+	ContentTopics     *[]string      `json:"content_topics,omitempty"`
+	TimeStart         *int64         `json:"time_start,omitempty"`
+	TimeEnd           *int64         `json:"time_end,omitempty"`
+	MessageHashes     *[]MessageHash `json:"message_hashes,omitempty"`
+	PaginationCursor  MessageHash    `json:"pagination_cursor,omitempty"`
+	PaginationForward bool           `json:"pagination_forward"`
+	PaginationLimit   *uint64        `json:"pagination_limit,omitempty"`
 }
 
 type StoreMessageResponse struct {
@@ -20,9 +20,9 @@ type StoreMessageResponse struct {
 }
 
 type StoreQueryResponse struct {
-	RequestId        string                 `json:"requestId,omitempty"`
-	StatusCode       *uint32                `json:"statusCode,omitempty"`
-	StatusDesc       string                 `json:"statusDesc,omitempty"`
-	Messages         []StoreMessageResponse `json:"messages,omitempty"`
-	PaginationCursor MessageHash            `json:"paginationCursor,omitempty"`
+	RequestId        string                  `json:"requestId,omitempty"`
+	StatusCode       *uint32                 `json:"statusCode,omitempty"`
+	StatusDesc       string                  `json:"statusDesc,omitempty"`
+	Messages         *[]StoreMessageResponse `json:"messages,omitempty"`
+	PaginationCursor MessageHash             `json:"paginationCursor,omitempty"`
 }

--- a/waku/common/store.go
+++ b/waku/common/store.go
@@ -1,0 +1,22 @@
+package common
+
+type StoreQueryRequest struct {
+	RequestId         string        `json:"requestId,omitempty"`
+	IncludeData       bool          `json:"includeData,omitempty"`
+	PubsubTopic       *string       `json:"pubsubTopic,omitempty"`
+	ContentTopics     []string      `json:"contentTopics,omitempty"`
+	TimeStart         *int64        `json:"timeStart,omitempty"`
+	TimeEnd           *int64        `json:"timeEnd,omitempty"`
+	MessageHashes     []MessageHash `json:"messageHashes,omitempty"`
+	PaginationCursor  []MessageHash `json:"paginationCursor,omitempty"`
+	PaginationForward bool          `json:"paginationForward,omitempty"`
+	PaginationLimit   *uint64       `json:"paginationLimit,omitempty"`
+}
+
+type StoreQueryResponse struct {
+	RequestId        string        `json:"request_id,omitempty"`
+	StatusCode       *uint32       `json:"status_code,omitempty"`
+	StatusDesc       *string       `json:"status_desc,omitempty"`
+	Messages         []*Envelope   `json:"messages,omitempty"`
+	PaginationCursor []MessageHash `json:"pagination_cursor,omitempty"`
+}

--- a/waku/common/store.go
+++ b/waku/common/store.go
@@ -8,15 +8,15 @@ type StoreQueryRequest struct {
 	TimeStart         *int64         `json:"time_start,omitempty"`
 	TimeEnd           *int64         `json:"time_end,omitempty"`
 	MessageHashes     *[]MessageHash `json:"message_hashes,omitempty"`
-	PaginationCursor  MessageHash    `json:"pagination_cursor,omitempty"`
+	PaginationCursor  *MessageHash   `json:"pagination_cursor,omitempty"`
 	PaginationForward bool           `json:"pagination_forward"`
 	PaginationLimit   *uint64        `json:"pagination_limit,omitempty"`
 }
 
 type StoreMessageResponse struct {
-	WakuMessage tmpWakuMessageJson `json:"message"`
-	PubsubTopic string             `json:"pubsubTopic"`
-	MessageHash MessageHash        `json:"messageHash"`
+	WakuMessage *tmpWakuMessageJson `json:"message"`
+	PubsubTopic string              `json:"pubsubTopic"`
+	MessageHash MessageHash         `json:"messageHash"`
 }
 
 type StoreQueryResponse struct {

--- a/waku/common/store.go
+++ b/waku/common/store.go
@@ -13,7 +13,7 @@ type StoreQueryRequest struct {
 	PaginationLimit   *uint64       `json:"pagination_limit,omitempty"`
 }
 
-type storeMessageResponse struct {
+type StoreMessageResponse struct {
 	WakuMessage tmpWakuMessageJson `json:"message"`
 	PubsubTopic string             `json:"pubsubTopic"`
 	MessageHash MessageHash        `json:"messageHash"`
@@ -23,6 +23,6 @@ type StoreQueryResponse struct {
 	RequestId        string                 `json:"requestId,omitempty"`
 	StatusCode       *uint32                `json:"statusCode,omitempty"`
 	StatusDesc       string                 `json:"statusDesc,omitempty"`
-	Messages         []storeMessageResponse `json:"messages,omitempty"`
+	Messages         []StoreMessageResponse `json:"messages,omitempty"`
 	PaginationCursor MessageHash            `json:"paginationCursor,omitempty"`
 }

--- a/waku/nwaku.go
+++ b/waku/nwaku.go
@@ -323,7 +323,6 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p/enode"
@@ -331,7 +330,6 @@ import (
 	libp2pproto "github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
-	storepb "github.com/waku-org/go-waku/waku/v2/protocol/store/pb"
 	"github.com/waku-org/go-waku/waku/v2/utils"
 	"github.com/waku-org/waku-go-bindings/waku/common"
 	"go.uber.org/zap"
@@ -827,7 +825,7 @@ func (n *WakuNode) Version() (string, error) {
 	return "", errors.New(errMsg)
 }
 
-func (n *WakuNode) StoreQuery(ctx context.Context, storeRequest *storepb.StoreQueryRequest, peerInfo peer.AddrInfo) (*storepb.StoreQueryResponse, error) {
+func (n *WakuNode) StoreQuery(ctx context.Context, storeRequest *common.StoreQueryRequest, peerInfo peer.AddrInfo) (*common.StoreQueryResponse, error) {
 	timeoutMs := getContextTimeoutMilliseconds(ctx)
 
 	b, err := json.Marshal(storeRequest)
@@ -856,7 +854,7 @@ func (n *WakuNode) StoreQuery(ctx context.Context, storeRequest *storepb.StoreQu
 
 	if C.getRet(resp) == C.RET_OK {
 		jsonResponseStr := C.GoStringN(C.getMyCharPtr(resp), C.int(C.getMyCharLen(resp)))
-		storeQueryResponse := &storepb.StoreQueryResponse{}
+		storeQueryResponse := &common.StoreQueryResponse{}
 		err = json.Unmarshal([]byte(jsonResponseStr), storeQueryResponse)
 		if err != nil {
 			return nil, err
@@ -868,12 +866,12 @@ func (n *WakuNode) StoreQuery(ctx context.Context, storeRequest *storepb.StoreQu
 	return nil, errors.New(errMsg)
 }
 
-func (n *WakuNode) RelayPublish(ctx context.Context, message *pb.WakuMessage, pubsubTopic string) (pb.MessageHash, error) {
+func (n *WakuNode) RelayPublish(ctx context.Context, message *pb.WakuMessage, pubsubTopic string) (common.MessageHash, error) {
 	timeoutMs := getContextTimeoutMilliseconds(ctx)
 
 	jsonMsg, err := json.Marshal(message)
 	if err != nil {
-		return pb.MessageHash{}, err
+		return common.MessageHash(""), err
 	}
 
 	wg := sync.WaitGroup{}
@@ -890,14 +888,14 @@ func (n *WakuNode) RelayPublish(ctx context.Context, message *pb.WakuMessage, pu
 	wg.Wait()
 	if C.getRet(resp) == C.RET_OK {
 		msgHash := C.GoStringN(C.getMyCharPtr(resp), C.int(C.getMyCharLen(resp)))
-		msgHashBytes, err := hexutil.Decode(msgHash)
+		parsedMsgHash, err := common.ToMessageHash(msgHash)
 		if err != nil {
-			return pb.MessageHash{}, err
+			return common.MessageHash(""), err
 		}
-		return pb.ToMessageHash(msgHashBytes), nil
+		return parsedMsgHash, nil
 	}
 	errMsg := "WakuRelayPublish: " + C.GoStringN(C.getMyCharPtr(resp), C.int(C.getMyCharLen(resp)))
-	return pb.MessageHash{}, errors.New(errMsg)
+	return common.MessageHash(""), errors.New(errMsg)
 }
 
 func (n *WakuNode) DnsDiscovery(ctx context.Context, enrTreeUrl string, nameDnsServer string) ([]multiaddr.Multiaddr, error) {

--- a/waku/nwaku.go
+++ b/waku/nwaku.go
@@ -829,13 +829,11 @@ func (n *WakuNode) Version() (string, error) {
 func (n *WakuNode) StoreQuery(ctx context.Context, storeRequest *common.StoreQueryRequest, peerInfo peer.AddrInfo) (*common.StoreQueryResponse, error) {
 	timeoutMs := getContextTimeoutMilliseconds(ctx)
 
-	fmt.Println("---------- StoreQuery 1 ---------")
 	b, err := json.Marshal(storeRequest)
 	if err != nil {
 		return nil, err
 	}
 
-	fmt.Println("---------- StoreQuery 2 ---------")
 	addrs := make([]string, len(peerInfo.Addrs))
 	for i, addr := range utils.EncapsulatePeerID(peerInfo.ID, peerInfo.Addrs...) {
 		addrs[i] = addr.String()

--- a/waku/nwaku_test.go
+++ b/waku/nwaku_test.go
@@ -636,7 +636,7 @@ func TestConnectionChange(t *testing.T) {
 	require.NoError(t, node2.Stop())
 }
 
-func TestHash(t *testing.T) {
+func TestStore(t *testing.T) {
 	logger, err := zap.NewDevelopment()
 	require.NoError(t, err)
 

--- a/waku/nwaku_test.go
+++ b/waku/nwaku_test.go
@@ -777,7 +777,7 @@ func TestStore(t *testing.T) {
 		PaginationLimit:   proto.Uint64(uint64(paginationLimit)),
 		PaginationForward: true,
 		TimeStart:         timeStart,
-		PaginationCursor:  res1.PaginationCursor,
+		PaginationCursor:  &res1.PaginationCursor,
 	}
 
 	ctx4, cancel4 := context.WithTimeout(context.Background(), requestTimeout)

--- a/waku/nwaku_test.go
+++ b/waku/nwaku_test.go
@@ -459,7 +459,7 @@ func TestRelay(t *testing.T) {
 		Payload:      []byte{1, 2, 3, 4, 5, 6},
 		ContentTopic: "test-content-topic",
 		Version:      proto.Uint32(0),
-		Timestamp:    proto.Int64(time.Now().Unix()),
+		Timestamp:    proto.Int64(time.Now().UnixNano()),
 	}
 	// send message
 	pubsubTopic := FormatWakuRelayTopic(senderNodeWakuConfig.ClusterID, senderNodeWakuConfig.Shards[0])
@@ -650,6 +650,7 @@ func TestHash(t *testing.T) {
 		Shards:          []uint16{64},
 		Discv5UdpPort:   9070,
 		TcpPort:         60070,
+		LegacyStore:     false,
 	}
 
 	fmt.Println("------------ creating node 1")
@@ -669,6 +670,7 @@ func TestHash(t *testing.T) {
 		Shards:          []uint16{64},
 		Discv5UdpPort:   9071,
 		TcpPort:         60071,
+		LegacyStore:     false,
 	}
 	receiverNode, err := NewWakuNode(&receiverNodeWakuConfig, logger.Named("receiverNode"))
 	require.NoError(t, err)
@@ -696,7 +698,7 @@ func TestHash(t *testing.T) {
 		Payload:      []byte{1, 2, 3, 4, 5, 6},
 		ContentTopic: "test-content-topic",
 		Version:      proto.Uint32(0),
-		Timestamp:    proto.Int64(time.Now().Unix()),
+		Timestamp:    proto.Int64(time.Now().UnixNano()),
 	}
 	// send message
 	pubsubTopic := FormatWakuRelayTopic(senderNodeWakuConfig.ClusterID, senderNodeWakuConfig.Shards[0])
@@ -719,7 +721,7 @@ func TestHash(t *testing.T) {
 		t.Fatal("Timeout: No message received within 10 seconds")
 	}
 
-	// No send store query
+	// Now send store query
 	ctx3, cancel3 := context.WithTimeout(context.Background(), requestTimeout)
 	defer cancel3()
 
@@ -728,12 +730,13 @@ func TestHash(t *testing.T) {
 		ContentTopics: []string{"test-content-topic"},
 	}
 
+	fmt.Println("------------ storeNode multiaddr: ", receiverMultiaddr[0].String())
 	storeNodeAddrInfo, err := peer.AddrInfoFromString(receiverMultiaddr[0].String())
 	require.NoError(t, err)
 
 	res, err := senderNode.StoreQuery(ctx3, &storeReq, *storeNodeAddrInfo)
 	require.NoError(t, err)
-	fmt.Println("----------- res: ", res)
+	fmt.Printf("%+v\n", res)
 
 	// Stop nodes
 	require.NoError(t, senderNode.Stop())

--- a/waku/nwaku_test.go
+++ b/waku/nwaku_test.go
@@ -750,7 +750,7 @@ func TestStore(t *testing.T) {
 	// Now send store query
 	storeReq1 := common.StoreQueryRequest{
 		IncludeData:       true,
-		ContentTopics:     []string{"test-content-topic"},
+		ContentTopics:     &[]string{"test-content-topic"},
 		PaginationLimit:   proto.Uint64(uint64(paginationLimit)),
 		PaginationForward: true,
 		TimeStart:         timeStart,
@@ -765,7 +765,7 @@ func TestStore(t *testing.T) {
 	res1, err := senderNode.StoreQuery(ctx3, &storeReq1, *storeNodeAddrInfo)
 	require.NoError(t, err)
 
-	storedMessages1 := res1.Messages
+	storedMessages1 := *res1.Messages
 	for i := 0; i < paginationLimit; i++ {
 		require.True(t, storedMessages1[i].MessageHash == hashes[i], fmt.Sprintf("Stored message does not match received message for index %d", i))
 	}
@@ -773,7 +773,7 @@ func TestStore(t *testing.T) {
 	// Now let's query the second page
 	storeReq2 := common.StoreQueryRequest{
 		IncludeData:       true,
-		ContentTopics:     []string{"test-content-topic"},
+		ContentTopics:     &[]string{"test-content-topic"},
 		PaginationLimit:   proto.Uint64(uint64(paginationLimit)),
 		PaginationForward: true,
 		TimeStart:         timeStart,
@@ -786,7 +786,7 @@ func TestStore(t *testing.T) {
 	res2, err := senderNode.StoreQuery(ctx4, &storeReq2, *storeNodeAddrInfo)
 	require.NoError(t, err)
 
-	storedMessages2 := res2.Messages
+	storedMessages2 := *res2.Messages
 	for i := 0; i < len(storedMessages2); i++ {
 		require.True(t, storedMessages2[i].MessageHash == hashes[i+paginationLimit], fmt.Sprintf("Stored message does not match received message for index %d", i))
 	}
@@ -794,8 +794,8 @@ func TestStore(t *testing.T) {
 	// Now let's query for two specific message hashes
 	storeReq3 := common.StoreQueryRequest{
 		IncludeData:   true,
-		ContentTopics: []string{"test-content-topic"},
-		MessageHashes: []common.MessageHash{hashes[0], hashes[2]},
+		ContentTopics: &[]string{"test-content-topic"},
+		MessageHashes: &[]common.MessageHash{hashes[0], hashes[2]},
 	}
 
 	ctx5, cancel5 := context.WithTimeout(context.Background(), requestTimeout)
@@ -804,7 +804,7 @@ func TestStore(t *testing.T) {
 	res3, err := senderNode.StoreQuery(ctx5, &storeReq3, *storeNodeAddrInfo)
 	require.NoError(t, err)
 
-	storedMessages3 := res3.Messages
+	storedMessages3 := *res3.Messages
 	require.True(t, storedMessages3[0].MessageHash == hashes[0], "Stored message does not match queried message")
 	require.True(t, storedMessages3[1].MessageHash == hashes[2], "Stored message does not match queried message")
 


### PR DESCRIPTION
Adapting the codebase to the usage of message hashes as hex strings in Relay and Store.

Included a new `MessageHash` type which is used whenever the bindings interact with message hashes, and added a test for Store.

A PR in nwaku returning message hashes in hex was also opened: https://github.com/waku-org/nwaku/pull/3234