### PR TITLE
chore: improve package structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Follow these steps to install and set up the module:
    ```
 3. Build the dependencies:
    ```
-   sudo make
+   sudo make -C waku
    ```
 
 Now the module is ready for use in your project.

--- a/waku/Makefile
+++ b/waku/Makefile
@@ -1,7 +1,7 @@
 # Makefile for Waku Go Bindings
 
 # Directories
-THIRD_PARTY_DIR := third_party
+THIRD_PARTY_DIR := ../third_party
 NWAKU_REPO := https://github.com/waku-org/nwaku
 NWAKU_DIR := $(THIRD_PARTY_DIR)/nwaku
 

--- a/waku/Makefile
+++ b/waku/Makefile
@@ -29,7 +29,7 @@ prepare:
 # Build Waku Go Bindings
 build: prepare
 	@echo "Building Waku Go Bindings..."
-	go build ./waku/...
+	go build ./...
 
 # Clean up generated files
 clean:


### PR DESCRIPTION
Moving the Makefile to the `waku` package so it is copied when adding the dependency with `go get`