### PR TITLE
fix: turning off omitempty for Relay

### DIFF
--- a/waku/nwaku.go
+++ b/waku/nwaku.go
@@ -344,7 +344,7 @@ const ConnectionChangeChanBufferSize = 100
 type WakuConfig struct {
 	Host                        string           `json:"host,omitempty"`
 	Nodekey                     string           `json:"nodekey,omitempty"`
-	Relay                       bool             `json:"relay,omitempty"`
+	Relay                       bool             `json:"relay"`
 	Store                       bool             `json:"store,omitempty"`
 	LegacyStore                 bool             `json:"legacyStore"`
 	Storenode                   string           `json:"storenode,omitempty"`


### PR DESCRIPTION
When having `omitempty` configured for Relay, whenever we set it to false it is considered as empty and the configuration is not sent to the nwaku node. As the default in `nwaku` is having Relay enabled, we end up having Relay enabled even if the user configured it false.

Therefore, removing the `omitempty` so we actually send the configuration when we disable it.