### PR TITLE
fix: hash to bytes conversion and increasing chan sizes

### DIFF
--- a/waku/common/message_hash.go
+++ b/waku/common/message_hash.go
@@ -35,5 +35,10 @@ func (h MessageHash) String() string {
 }
 
 func (h MessageHash) Bytes() ([]byte, error) {
-	return hex.DecodeString(string(h))
+	s := string(h)
+	// Remove 0x prefix if present
+	if len(s) >= 2 && s[:2] == "0x" {
+		s = s[2:]
+	}
+	return hex.DecodeString(s)
 }

--- a/waku/nwaku.go
+++ b/waku/nwaku.go
@@ -337,9 +337,9 @@ import (
 )
 
 const requestTimeout = 30 * time.Second
-const MsgChanBufferSize = 100
-const TopicHealthChanBufferSize = 100
-const ConnectionChangeChanBufferSize = 100
+const MsgChanBufferSize = 1024
+const TopicHealthChanBufferSize = 1024
+const ConnectionChangeChanBufferSize = 1024
 
 type WakuConfig struct {
 	Host                        string           `json:"host,omitempty"`


### PR DESCRIPTION
Fixing our hash to bytes conversion to omit the `0x` prefix if existent, and increasing the channels' buffers to 1024 to match go-waku's size