### PR TITLE
chore: moving types to common package

### DIFF
--- a/waku/common/config.go
+++ b/waku/common/config.go
@@ -1,0 +1,82 @@
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type WakuConfig struct {
+	Host                        string           `json:"host,omitempty"`
+	Nodekey                     string           `json:"nodekey,omitempty"`
+	Relay                       bool             `json:"relay"`
+	Store                       bool             `json:"store,omitempty"`
+	LegacyStore                 bool             `json:"legacyStore"`
+	Storenode                   string           `json:"storenode,omitempty"`
+	StoreMessageRetentionPolicy string           `json:"storeMessageRetentionPolicy,omitempty"`
+	StoreMessageDbUrl           string           `json:"storeMessageDbUrl,omitempty"`
+	StoreMessageDbVacuum        bool             `json:"storeMessageDbVacuum,omitempty"`
+	StoreMaxNumDbConnections    int              `json:"storeMaxNumDbConnections,omitempty"`
+	StoreResume                 bool             `json:"storeResume,omitempty"`
+	Filter                      bool             `json:"filter,omitempty"`
+	Filternode                  string           `json:"filternode,omitempty"`
+	FilterSubscriptionTimeout   int64            `json:"filterSubscriptionTimeout,omitempty"`
+	FilterMaxPeersToServe       uint32           `json:"filterMaxPeersToServe,omitempty"`
+	FilterMaxCriteria           uint32           `json:"filterMaxCriteria,omitempty"`
+	Lightpush                   bool             `json:"lightpush,omitempty"`
+	LightpushNode               string           `json:"lightpushnode,omitempty"`
+	LogLevel                    string           `json:"logLevel,omitempty"`
+	DnsDiscovery                bool             `json:"dnsDiscovery,omitempty"`
+	DnsDiscoveryUrl             string           `json:"dnsDiscoveryUrl,omitempty"`
+	MaxMessageSize              string           `json:"maxMessageSize,omitempty"`
+	Staticnodes                 []string         `json:"staticnodes,omitempty"`
+	Discv5BootstrapNodes        []string         `json:"discv5BootstrapNodes,omitempty"`
+	Discv5Discovery             bool             `json:"discv5Discovery,omitempty"`
+	Discv5UdpPort               int              `json:"discv5UdpPort,omitempty"`
+	ClusterID                   uint16           `json:"clusterId,omitempty"`
+	Shards                      []uint16         `json:"shards,omitempty"`
+	PeerExchange                bool             `json:"peerExchange,omitempty"`
+	PeerExchangeNode            string           `json:"peerExchangeNode,omitempty"`
+	TcpPort                     int              `json:"tcpPort,omitempty"`
+	RateLimits                  RateLimitsConfig `json:"rateLimits,omitempty"`
+}
+
+type RateLimitsConfig struct {
+	Filter       *RateLimit `json:"-"`
+	Lightpush    *RateLimit `json:"-"`
+	PeerExchange *RateLimit `json:"-"`
+}
+
+type RateLimit struct {
+	Volume   int               // Number of allowed messages per period
+	Period   int               // Length of each rate-limit period (in TimeUnit)
+	TimeUnit RateLimitTimeUnit // Time unit of the period
+}
+
+type RateLimitTimeUnit string
+
+const Hour RateLimitTimeUnit = "h"
+const Minute RateLimitTimeUnit = "m"
+const Second RateLimitTimeUnit = "s"
+const Millisecond RateLimitTimeUnit = "ms"
+
+func (rl RateLimit) String() string {
+	return fmt.Sprintf("%d/%d%s", rl.Volume, rl.Period, rl.TimeUnit)
+}
+
+func (rl RateLimit) MarshalJSON() ([]byte, error) {
+	return json.Marshal(rl.String())
+}
+
+func (rlc RateLimitsConfig) MarshalJSON() ([]byte, error) {
+	output := []string{}
+	if rlc.Filter != nil {
+		output = append(output, fmt.Sprintf("filter:%s", rlc.Filter.String()))
+	}
+	if rlc.Lightpush != nil {
+		output = append(output, fmt.Sprintf("lightpush:%s", rlc.Lightpush.String()))
+	}
+	if rlc.PeerExchange != nil {
+		output = append(output, fmt.Sprintf("px:%s", rlc.PeerExchange.String()))
+	}
+	return json.Marshal(output)
+}

--- a/waku/common/config.go
+++ b/waku/common/config.go
@@ -1,10 +1,5 @@
 package common
 
-import (
-	"encoding/json"
-	"fmt"
-)
-
 type WakuConfig struct {
 	Host                        string           `json:"host,omitempty"`
 	Nodekey                     string           `json:"nodekey,omitempty"`
@@ -38,45 +33,4 @@ type WakuConfig struct {
 	PeerExchangeNode            string           `json:"peerExchangeNode,omitempty"`
 	TcpPort                     int              `json:"tcpPort,omitempty"`
 	RateLimits                  RateLimitsConfig `json:"rateLimits,omitempty"`
-}
-
-type RateLimitsConfig struct {
-	Filter       *RateLimit `json:"-"`
-	Lightpush    *RateLimit `json:"-"`
-	PeerExchange *RateLimit `json:"-"`
-}
-
-type RateLimit struct {
-	Volume   int               // Number of allowed messages per period
-	Period   int               // Length of each rate-limit period (in TimeUnit)
-	TimeUnit RateLimitTimeUnit // Time unit of the period
-}
-
-type RateLimitTimeUnit string
-
-const Hour RateLimitTimeUnit = "h"
-const Minute RateLimitTimeUnit = "m"
-const Second RateLimitTimeUnit = "s"
-const Millisecond RateLimitTimeUnit = "ms"
-
-func (rl RateLimit) String() string {
-	return fmt.Sprintf("%d/%d%s", rl.Volume, rl.Period, rl.TimeUnit)
-}
-
-func (rl RateLimit) MarshalJSON() ([]byte, error) {
-	return json.Marshal(rl.String())
-}
-
-func (rlc RateLimitsConfig) MarshalJSON() ([]byte, error) {
-	output := []string{}
-	if rlc.Filter != nil {
-		output = append(output, fmt.Sprintf("filter:%s", rlc.Filter.String()))
-	}
-	if rlc.Lightpush != nil {
-		output = append(output, fmt.Sprintf("lightpush:%s", rlc.Lightpush.String()))
-	}
-	if rlc.PeerExchange != nil {
-		output = append(output, fmt.Sprintf("px:%s", rlc.PeerExchange.String()))
-	}
-	return json.Marshal(output)
 }

--- a/waku/common/rate_limit.go
+++ b/waku/common/rate_limit.go
@@ -1,0 +1,47 @@
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type RateLimitsConfig struct {
+	Filter       *RateLimit `json:"-"`
+	Lightpush    *RateLimit `json:"-"`
+	PeerExchange *RateLimit `json:"-"`
+}
+
+type RateLimit struct {
+	Volume   int               // Number of allowed messages per period
+	Period   int               // Length of each rate-limit period (in TimeUnit)
+	TimeUnit RateLimitTimeUnit // Time unit of the period
+}
+
+type RateLimitTimeUnit string
+
+const Hour RateLimitTimeUnit = "h"
+const Minute RateLimitTimeUnit = "m"
+const Second RateLimitTimeUnit = "s"
+const Millisecond RateLimitTimeUnit = "ms"
+
+func (rl RateLimit) String() string {
+	return fmt.Sprintf("%d/%d%s", rl.Volume, rl.Period, rl.TimeUnit)
+}
+
+func (rl RateLimit) MarshalJSON() ([]byte, error) {
+	return json.Marshal(rl.String())
+}
+
+func (rlc RateLimitsConfig) MarshalJSON() ([]byte, error) {
+	output := []string{}
+	if rlc.Filter != nil {
+		output = append(output, fmt.Sprintf("filter:%s", rlc.Filter.String()))
+	}
+	if rlc.Lightpush != nil {
+		output = append(output, fmt.Sprintf("lightpush:%s", rlc.Lightpush.String()))
+	}
+	if rlc.PeerExchange != nil {
+		output = append(output, fmt.Sprintf("px:%s", rlc.PeerExchange.String()))
+	}
+	return json.Marshal(output)
+}

--- a/waku/nwaku.go
+++ b/waku/nwaku.go
@@ -341,82 +341,6 @@ const MsgChanBufferSize = 1024
 const TopicHealthChanBufferSize = 1024
 const ConnectionChangeChanBufferSize = 1024
 
-type WakuConfig struct {
-	Host                        string           `json:"host,omitempty"`
-	Nodekey                     string           `json:"nodekey,omitempty"`
-	Relay                       bool             `json:"relay"`
-	Store                       bool             `json:"store,omitempty"`
-	LegacyStore                 bool             `json:"legacyStore"`
-	Storenode                   string           `json:"storenode,omitempty"`
-	StoreMessageRetentionPolicy string           `json:"storeMessageRetentionPolicy,omitempty"`
-	StoreMessageDbUrl           string           `json:"storeMessageDbUrl,omitempty"`
-	StoreMessageDbVacuum        bool             `json:"storeMessageDbVacuum,omitempty"`
-	StoreMaxNumDbConnections    int              `json:"storeMaxNumDbConnections,omitempty"`
-	StoreResume                 bool             `json:"storeResume,omitempty"`
-	Filter                      bool             `json:"filter,omitempty"`
-	Filternode                  string           `json:"filternode,omitempty"`
-	FilterSubscriptionTimeout   int64            `json:"filterSubscriptionTimeout,omitempty"`
-	FilterMaxPeersToServe       uint32           `json:"filterMaxPeersToServe,omitempty"`
-	FilterMaxCriteria           uint32           `json:"filterMaxCriteria,omitempty"`
-	Lightpush                   bool             `json:"lightpush,omitempty"`
-	LightpushNode               string           `json:"lightpushnode,omitempty"`
-	LogLevel                    string           `json:"logLevel,omitempty"`
-	DnsDiscovery                bool             `json:"dnsDiscovery,omitempty"`
-	DnsDiscoveryUrl             string           `json:"dnsDiscoveryUrl,omitempty"`
-	MaxMessageSize              string           `json:"maxMessageSize,omitempty"`
-	Staticnodes                 []string         `json:"staticnodes,omitempty"`
-	Discv5BootstrapNodes        []string         `json:"discv5BootstrapNodes,omitempty"`
-	Discv5Discovery             bool             `json:"discv5Discovery,omitempty"`
-	Discv5UdpPort               int              `json:"discv5UdpPort,omitempty"`
-	ClusterID                   uint16           `json:"clusterId,omitempty"`
-	Shards                      []uint16         `json:"shards,omitempty"`
-	PeerExchange                bool             `json:"peerExchange,omitempty"`
-	PeerExchangeNode            string           `json:"peerExchangeNode,omitempty"`
-	TcpPort                     int              `json:"tcpPort,omitempty"`
-	RateLimits                  RateLimitsConfig `json:"rateLimits,omitempty"`
-}
-
-type RateLimitsConfig struct {
-	Filter       *RateLimit `json:"-"`
-	Lightpush    *RateLimit `json:"-"`
-	PeerExchange *RateLimit `json:"-"`
-}
-
-func (rlc RateLimitsConfig) MarshalJSON() ([]byte, error) {
-	output := []string{}
-	if rlc.Filter != nil {
-		output = append(output, fmt.Sprintf("filter:%s", rlc.Filter.String()))
-	}
-	if rlc.Lightpush != nil {
-		output = append(output, fmt.Sprintf("lightpush:%s", rlc.Lightpush.String()))
-	}
-	if rlc.PeerExchange != nil {
-		output = append(output, fmt.Sprintf("px:%s", rlc.PeerExchange.String()))
-	}
-	return json.Marshal(output)
-}
-
-type RateLimitTimeUnit string
-
-const Hour RateLimitTimeUnit = "h"
-const Minute RateLimitTimeUnit = "m"
-const Second RateLimitTimeUnit = "s"
-const Millisecond RateLimitTimeUnit = "ms"
-
-type RateLimit struct {
-	Volume   int               // Number of allowed messages per period
-	Period   int               // Length of each rate-limit period (in TimeUnit)
-	TimeUnit RateLimitTimeUnit // Time unit of the period
-}
-
-func (rl RateLimit) String() string {
-	return fmt.Sprintf("%d/%d%s", rl.Volume, rl.Period, rl.TimeUnit)
-}
-
-func (rl RateLimit) MarshalJSON() ([]byte, error) {
-	return json.Marshal(rl.String())
-}
-
 //export GoCallback
 func GoCallback(ret C.int, msg *C.char, len C.size_t, resp unsafe.Pointer) {
 	if resp != nil {
@@ -432,14 +356,14 @@ func GoCallback(ret C.int, msg *C.char, len C.size_t, resp unsafe.Pointer) {
 // WakuNode represents an instance of an nwaku node
 type WakuNode struct {
 	wakuCtx              unsafe.Pointer
-	config               *WakuConfig
+	config               *common.WakuConfig
 	MsgChan              chan common.Envelope
 	TopicHealthChan      chan topicHealth
 	ConnectionChangeChan chan connectionChange
 	nodeName             string
 }
 
-func NewWakuNode(config *WakuConfig, nodeName string) (*WakuNode, error) {
+func NewWakuNode(config *common.WakuConfig, nodeName string) (*WakuNode, error) {
 	Debug("Creating new WakuNode: %v", nodeName)
 	n := &WakuNode{
 		config:   config,
@@ -1359,11 +1283,11 @@ func GetFreePortIfNeeded(tcpPort int, discV5UDPPort int) (int, int, error) {
 }
 
 // Create & start node
-func StartWakuNode(nodeName string, customCfg *WakuConfig) (*WakuNode, error) {
+func StartWakuNode(nodeName string, customCfg *common.WakuConfig) (*WakuNode, error) {
 
 	Debug("Initializing %s", nodeName)
 
-	var nodeCfg WakuConfig
+	var nodeCfg common.WakuConfig
 	if customCfg == nil {
 		nodeCfg = DefaultWakuConfig
 	} else {

--- a/waku/nwaku_test.go
+++ b/waku/nwaku_test.go
@@ -37,7 +37,7 @@ func TestBasicWaku(t *testing.T) {
 
 	// ctx := context.Background()
 
-	nwakuConfig := WakuConfig{
+	nwakuConfig := common.WakuConfig{
 		Nodekey:         "11d0dcea28e86f81937a3bd1163473c7fbc0a0db54fd72914849bc47bdf78710",
 		Relay:           true,
 		LogLevel:        "DEBUG",
@@ -190,7 +190,7 @@ func TestPeerExchange(t *testing.T) {
 	tcpPort, udpPort, err := GetFreePortIfNeeded(0, 0)
 	require.NoError(t, err)
 	// start node that will be discovered by PeerExchange
-	discV5NodeWakuConfig := WakuConfig{
+	discV5NodeWakuConfig := common.WakuConfig{
 		Relay:           true,
 		LogLevel:        "DEBUG",
 		Discv5Discovery: true,
@@ -215,7 +215,7 @@ func TestPeerExchange(t *testing.T) {
 	require.NoError(t, err)
 
 	// start node which serves as PeerExchange server
-	pxServerWakuConfig := WakuConfig{
+	pxServerWakuConfig := common.WakuConfig{
 		Relay:                true,
 		LogLevel:             "DEBUG",
 		Discv5Discovery:      true,
@@ -264,7 +264,7 @@ func TestPeerExchange(t *testing.T) {
 	require.NoError(t, err)
 
 	// start light node which uses PeerExchange to discover peers
-	pxClientWakuConfig := WakuConfig{
+	pxClientWakuConfig := common.WakuConfig{
 		Relay:            false,
 		LogLevel:         "DEBUG",
 		Discv5Discovery:  false,
@@ -324,7 +324,7 @@ func TestDnsDiscover(t *testing.T) {
 	require.NoError(t, err)
 
 	nameserver := "8.8.8.8"
-	nodeWakuConfig := WakuConfig{
+	nodeWakuConfig := common.WakuConfig{
 		Relay:         true,
 		LogLevel:      "DEBUG",
 		ClusterID:     16,
@@ -353,7 +353,7 @@ func TestDial(t *testing.T) {
 	require.NoError(t, err)
 
 	// start node that will initiate the dial
-	dialerNodeWakuConfig := WakuConfig{
+	dialerNodeWakuConfig := common.WakuConfig{
 		Relay:           true,
 		LogLevel:        "DEBUG",
 		Discv5Discovery: false,
@@ -371,7 +371,7 @@ func TestDial(t *testing.T) {
 	require.NoError(t, err)
 
 	// start node that will receive the dial
-	receiverNodeWakuConfig := WakuConfig{
+	receiverNodeWakuConfig := common.WakuConfig{
 		Relay:           true,
 		LogLevel:        "DEBUG",
 		Discv5Discovery: false,
@@ -418,7 +418,7 @@ func TestRelay(t *testing.T) {
 	require.NoError(t, err)
 
 	// start node that will send the message
-	senderNodeWakuConfig := WakuConfig{
+	senderNodeWakuConfig := common.WakuConfig{
 		Relay:           true,
 		LogLevel:        "DEBUG",
 		Discv5Discovery: false,
@@ -436,7 +436,7 @@ func TestRelay(t *testing.T) {
 	require.NoError(t, err)
 
 	// start node that will receive the message
-	receiverNodeWakuConfig := WakuConfig{
+	receiverNodeWakuConfig := common.WakuConfig{
 		Relay:           true,
 		LogLevel:        "DEBUG",
 		Discv5Discovery: false,
@@ -502,7 +502,7 @@ func TestTopicHealth(t *testing.T) {
 	require.NoError(t, err)
 
 	// start node1
-	wakuConfig1 := WakuConfig{
+	wakuConfig1 := common.WakuConfig{
 		Relay:           true,
 		LogLevel:        "DEBUG",
 		Discv5Discovery: false,
@@ -520,7 +520,7 @@ func TestTopicHealth(t *testing.T) {
 	require.NoError(t, err)
 
 	// start node2
-	wakuConfig2 := WakuConfig{
+	wakuConfig2 := common.WakuConfig{
 		Relay:           true,
 		LogLevel:        "DEBUG",
 		Discv5Discovery: false,
@@ -575,7 +575,7 @@ func TestConnectionChange(t *testing.T) {
 	require.NoError(t, err)
 
 	// start node1
-	wakuConfig1 := WakuConfig{
+	wakuConfig1 := common.WakuConfig{
 		Relay:           true,
 		LogLevel:        "DEBUG",
 		Discv5Discovery: false,
@@ -593,7 +593,7 @@ func TestConnectionChange(t *testing.T) {
 	require.NoError(t, err)
 
 	// start node2
-	wakuConfig2 := WakuConfig{
+	wakuConfig2 := common.WakuConfig{
 		Relay:           true,
 		LogLevel:        "DEBUG",
 		Discv5Discovery: false,
@@ -662,7 +662,7 @@ func TestStore(t *testing.T) {
 	require.NoError(t, err)
 
 	// start node that will send the message
-	senderNodeWakuConfig := WakuConfig{
+	senderNodeWakuConfig := common.WakuConfig{
 		Relay:           true,
 		Store:           true,
 		LogLevel:        "DEBUG",
@@ -682,7 +682,7 @@ func TestStore(t *testing.T) {
 	require.NoError(t, err)
 
 	// start node that will receive the message
-	receiverNodeWakuConfig := WakuConfig{
+	receiverNodeWakuConfig := common.WakuConfig{
 		Relay:           true,
 		Store:           true,
 		LogLevel:        "DEBUG",
@@ -845,7 +845,7 @@ func TestParallelPings(t *testing.T) {
 	require.NoError(t, err)
 
 	// start node that will initiate the dial
-	dialerNodeWakuConfig := WakuConfig{
+	dialerNodeWakuConfig := common.WakuConfig{
 		Relay:           true,
 		LogLevel:        "DEBUG",
 		Discv5Discovery: false,
@@ -862,7 +862,7 @@ func TestParallelPings(t *testing.T) {
 	tcpPort, udpPort, err = GetFreePortIfNeeded(0, 0)
 	require.NoError(t, err)
 
-	receiverNodeWakuConfig1 := WakuConfig{
+	receiverNodeWakuConfig1 := common.WakuConfig{
 		Relay:           true,
 		LogLevel:        "DEBUG",
 		Discv5Discovery: false,
@@ -883,7 +883,7 @@ func TestParallelPings(t *testing.T) {
 	tcpPort, udpPort, err = GetFreePortIfNeeded(0, 0)
 	require.NoError(t, err)
 
-	receiverNodeWakuConfig2 := WakuConfig{
+	receiverNodeWakuConfig2 := common.WakuConfig{
 		Relay:           true,
 		LogLevel:        "DEBUG",
 		Discv5Discovery: false,
@@ -904,7 +904,7 @@ func TestParallelPings(t *testing.T) {
 	tcpPort, udpPort, err = GetFreePortIfNeeded(0, 0)
 	require.NoError(t, err)
 
-	receiverNodeWakuConfig3 := WakuConfig{
+	receiverNodeWakuConfig3 := common.WakuConfig{
 		Relay:           true,
 		LogLevel:        "DEBUG",
 		Discv5Discovery: false,

--- a/waku/test_data.go
+++ b/waku/test_data.go
@@ -2,9 +2,11 @@ package waku
 
 import (
 	"time"
+
+	"github.com/waku-org/waku-go-bindings/waku/common"
 )
 
-var DefaultWakuConfig WakuConfig
+var DefaultWakuConfig common.WakuConfig
 
 func init() {
 
@@ -15,7 +17,7 @@ func init() {
 		Error("Failed to get free ports %v %v", err1, err2)
 	}
 
-	DefaultWakuConfig = WakuConfig{
+	DefaultWakuConfig = common.WakuConfig{
 		Relay:           false,
 		LogLevel:        "DEBUG",
 		Discv5Discovery: true,


### PR DESCRIPTION
Moving types that will be needed by `status-go` without nwaku to the `common` package.
This will allow proper compilation of the dependency even when nwaku is not used, and it will spare us from having to clone nwaku at all if it's not needed.

