### PR TITLE
fix: unregistering node when destroying

### DIFF
--- a/waku/nwaku.go
+++ b/waku/nwaku.go
@@ -997,6 +997,7 @@ func (n *WakuNode) Destroy() error {
 	wg.Wait()
 
 	if C.getRet(resp) == C.RET_OK {
+		unregisterNode(n)
 		Debug("Successfully destroyed %s", n.nodeName)
 		return nil
 	}


### PR DESCRIPTION
Whenever we destroy a node we should delete it from our node registry. Otherwise, the same pointer may be used by a new node and the already destroyed `WakuNode`'s struct will be mistakenly taken from the registry on events instead of the newer node.