### PR TITLE
chore: adding link to example-go-bindings repo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,7 @@ buildlib:
    sudo chown $(USER) third_party &&\
    make -C waku
 ```
+
+## Example Usage
+
+For an example on how to use this package, please take a look at our [example-go-bindings](https://github.com/gabrielmer/example-waku-go-bindings) repo


### PR DESCRIPTION
Adding a link to the `example-go-bindings` repo for users to use as a reference if needed