### PR TITLE
feat: integrating waku_relay_get_peers_in_mesh

### DIFF
--- a/waku/nwaku.go
+++ b/waku/nwaku.go
@@ -602,11 +602,11 @@ func (n *WakuNode) GetConnectedPeers() (peer.IDSlice, error) {
 func (n *WakuNode) GetPeersInMesh(pubsubTopic string) (peer.IDSlice, error) {
 	if n == nil {
 		err := errors.New("waku node is nil")
-		Error("Failed to get peers in mesh %v", err)
+		Error("Failed to get peers in mesh: %v", err)
 		return nil, err
 	}
 
-	Debug("Fetching connected peers for %v", n.nodeName)
+	Debug("Fetching peers in mesh peers for pubsubTopic: %v, node: %v", pubsubTopic, n.nodeName)
 
 	wg := sync.WaitGroup{}
 	var resp = C.allocResp(unsafe.Pointer(&wg))
@@ -1294,7 +1294,7 @@ func (n *WakuNode) GetNumConnectedPeers() (int, error) {
 
 	peers, err := n.GetConnectedPeers()
 	if err != nil {
-		Error("Failed to fetch connected peers for %v %v ", n.nodeName, err)
+		Error("Failed to fetch connected peers for %v: %v ", n.nodeName, err)
 		return 0, err
 	}
 

--- a/waku/nwaku.go
+++ b/waku/nwaku.go
@@ -641,8 +641,8 @@ func (n *WakuNode) GetPeersInMesh(pubsubTopic string) (peer.IDSlice, error) {
 		return peers, nil
 	}
 
-	errMsg := "error GetConnectedPeers: " + C.GoStringN(C.getMyCharPtr(resp), C.int(C.getMyCharLen(resp)))
-	Error("Failed to get connected peers for %v: %v", n.nodeName, errMsg)
+	errMsg := "error GetPeersInMesh: " + C.GoStringN(C.getMyCharPtr(resp), C.int(C.getMyCharLen(resp)))
+	Error("Failed to get peers in mesh for pubsubTopic: %v:, node: %v. %v", pubsubTopic, n.nodeName, errMsg)
 
 	return nil, errors.New(errMsg)
 }


### PR DESCRIPTION
Integrating libwaku's `waku_relay_get_peers_in_mesh` function introduced in https://github.com/waku-org/nwaku/pull/3352 and adding test (same test as for `waku_relay_get_num_peers_in_mesh` but checking the peerIds)