### PR TITLE
feat: integrating waku_relay_get_connected_peers

### DIFF
--- a/waku/test_data.go
+++ b/waku/test_data.go
@@ -10,7 +10,7 @@ import (
 
 var DefaultWakuConfig common.WakuConfig
 var DefaultStoreQueryRequest common.StoreQueryRequest
-var DEFAULT_CLUSTER_ID = 16
+var DEFAULT_CLUSTER_ID = uint16(16)
 
 func init() {
 


### PR DESCRIPTION
Integrating libwaku's `waku_relay_get_connected_peers` function introduced in https://github.com/waku-org/nwaku/pull/3353 and adding test