### PR TITLE
chore: using envelope type instead of interface

### DIFF
--- a/waku/common/envelope.go
+++ b/waku/common/envelope.go
@@ -9,13 +9,7 @@ import (
 // Envelope contains information about the pubsub topic of a WakuMessage
 // and a hash used to identify a message based on the bytes of a WakuMessage
 // protobuffer
-type Envelope interface {
-	Message() *pb.WakuMessage
-	PubsubTopic() string
-	Hash() MessageHash
-}
-
-type envelopeImpl struct {
+type Envelope struct {
 	msg   *pb.WakuMessage
 	topic string
 	hash  MessageHash
@@ -38,18 +32,14 @@ type tmpEnvelopeStruct struct {
 }
 
 // NewEnvelope creates a new Envelope from a json string generated in nwaku
-func NewEnvelope(jsonEventStr string) (Envelope, error) {
+func NewEnvelope(jsonEventStr string) (*Envelope, error) {
 	tmpEnvelopeStruct := tmpEnvelopeStruct{}
 	err := json.Unmarshal([]byte(jsonEventStr), &tmpEnvelopeStruct)
 	if err != nil {
 		return nil, err
 	}
 
-	if err != nil {
-		return nil, err
-	}
-
-	return &envelopeImpl{
+	return &Envelope{
 		msg: &pb.WakuMessage{
 			Payload:        tmpEnvelopeStruct.WakuMessage.Payload,
 			ContentTopic:   tmpEnvelopeStruct.WakuMessage.ContentTopic,
@@ -64,14 +54,14 @@ func NewEnvelope(jsonEventStr string) (Envelope, error) {
 	}, nil
 }
 
-func (e *envelopeImpl) Message() *pb.WakuMessage {
+func (e *Envelope) Message() *pb.WakuMessage {
 	return e.msg
 }
 
-func (e *envelopeImpl) PubsubTopic() string {
+func (e *Envelope) PubsubTopic() string {
 	return e.topic
 }
 
-func (e *envelopeImpl) Hash() MessageHash {
+func (e *Envelope) Hash() MessageHash {
 	return e.hash
 }

--- a/waku/nwaku.go
+++ b/waku/nwaku.go
@@ -484,7 +484,7 @@ func (n *WakuNode) parseMessageEvent(eventStr string) {
 	if err != nil {
 		Error("could not parse message %v", err)
 	}
-	n.MsgChan <- envelope
+	n.MsgChan <- *envelope
 }
 
 func (n *WakuNode) parseTopicHealthChangeEvent(eventStr string) {

--- a/waku/nwaku_test_utils.go
+++ b/waku/nwaku_test_utils.go
@@ -155,10 +155,6 @@ func (n *WakuNode) VerifyMessageReceived(expectedMessage *pb.WakuMessage, expect
 
 	select {
 	case envelope := <-n.MsgChan:
-		if envelope == nil {
-			Error("Received envelope is nil on node %s", n.nodeName)
-			return errors.New("received envelope is nil")
-		}
 		if string(expectedMessage.Payload) != string(envelope.Message().Payload) {
 			Error("Payload does not match on node %s", n.nodeName)
 			return errors.New("payload does not match")


### PR DESCRIPTION
Defining an Envelope type as in https://github.com/waku-org/go-waku/blob/master/waku/v2/protocol/envelope.go so it can be used directly in `status-go`