### PR TITLE
Adjust count of each test runs to 15

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,7 +39,8 @@ jobs:
 
       - name: Run Daily Test
         run: |
-          go test -count=5 -p=1 -v -timeout=360m ./waku \
+          set -euo pipefail
+          go test -count=10 -p=1 -v -timeout=360m ./waku \
             | tee testlogs.log
 
       - name: Upload Test Logs

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Run Daily Test
         run: |
           go test -count=5 -p=1 -v -timeout=360m ./waku \
-+            | tee testlogs.log
+            | tee testlogs.log
 
       - name: Upload Test Logs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,8 +39,8 @@ jobs:
 
       - name: Run Daily Test
         run: |
-          go test -p=1 -v ./waku -count=15 -timeout=360m \
-            | tee testlogs.log
+          go test -count=5 -p=1 -v -timeout=360m ./waku \
++            | tee testlogs.log
 
       - name: Upload Test Logs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,9 +37,9 @@ jobs:
       - name: Increase ulimit
         run: sudo sh -c "ulimit -n 8192"  
 
-      - name: Run Endurance Test
+      - name: Run Daily Test
         run: |
-          go test -p=1 -v ./waku -count=1 -timeout=360m \
+          go test -p=1 -v ./waku -count=15 -timeout=360m \
             | tee testlogs.log
 
       - name: Upload Test Logs


### PR DESCRIPTION
This pull-request tightens our GitHub Actions workflow:

Repeat tests ten times
We pass -count=10 to go test, so each test function executes ten consecutive times. Flaky behaviour surfaces quickly.

Stop the job as soon as something fails
The step now begins with set -euo pipefail. If go test returns a non-zero exit code, the pipeline exits immediately and the job turns red instead of masking the failure behind tee.