### PR TITLE
chore: exposing additional nwaku configurations

### DIFF
--- a/waku/common/config.go
+++ b/waku/common/config.go
@@ -33,4 +33,8 @@ type WakuConfig struct {
 	PeerExchangeNode            string           `json:"peerExchangeNode,omitempty"`
 	TcpPort                     int              `json:"tcpPort,omitempty"`
 	RateLimits                  RateLimitsConfig `json:"rateLimits,omitempty"`
+	DnsDiscoveryNameServers     []string         `json:"dnsDiscoveryNameServers,omitempty"`
+	DnsAddrsNameServers         []string         `json:"dnsAddrsNameServers,omitempty"`
+	Discv5EnrAutoUpdate         bool             `json:"discv5EnrAutoUpdate,omitempty"`
+	MaxConnections              int              `json:"maxConnections,omitempty"`
 }


### PR DESCRIPTION
Exposing the following nwaku configurations:
- `dnsDiscoveryNameServers`
- `dnsAddrsNameServers`
- `discv5EnrAutoUpdate`
- `maxConnections`