### PR TITLE
chore: removing deprecated DnsDiscoveryNameServers config

### DIFF
--- a/waku/common/config.go
+++ b/waku/common/config.go
@@ -33,7 +33,6 @@ type WakuConfig struct {
 	PeerExchangeNode            string           `json:"peerExchangeNode,omitempty"`
 	TcpPort                     int              `json:"tcpPort,omitempty"`
 	RateLimits                  RateLimitsConfig `json:"rateLimits,omitempty"`
-	DnsDiscoveryNameServers     []string         `json:"dnsDiscoveryNameServers,omitempty"`
 	DnsAddrsNameServers         []string         `json:"dnsAddrsNameServers,omitempty"`
 	Discv5EnrAutoUpdate         bool             `json:"discv5EnrAutoUpdate,omitempty"`
 	MaxConnections              int              `json:"maxConnections,omitempty"`


### PR DESCRIPTION
Removing `DnsDiscoveryNameServers` from the configurations as it was removed in https://github.com/waku-org/nwaku/commit/e42e28cc6f5f464d1efa65f8ed0b8ae58923f0de#diff-43f34e84eeb9a4b4061898c3bd78274e149e50bd6b5d24aeb0a982e07629172e