### PR TITLE
fix: return value check, support numShardsInNetwork

### DIFF
--- a/waku/common/config.go
+++ b/waku/common/config.go
@@ -36,4 +36,5 @@ type WakuConfig struct {
 	DnsAddrsNameServers         []string         `json:"dnsAddrsNameServers,omitempty"`
 	Discv5EnrAutoUpdate         bool             `json:"discv5EnrAutoUpdate,omitempty"`
 	MaxConnections              int              `json:"maxConnections,omitempty"`
+	NumShardsInNetwork          uint16           `json:"numShardsInNetwork"`
 }

--- a/waku/nwaku.go
+++ b/waku/nwaku.go
@@ -398,15 +398,15 @@ func NewWakuNode(config *common.WakuConfig, nodeName string) (*WakuNode, error) 
 	defer C.free(unsafe.Pointer(cJsonConfig))
 	defer C.freeResp(resp)
 
+	wg.Add(1)
+	n.wakuCtx = C.cGoWakuNew(cJsonConfig, resp)
+	wg.Wait()
+
 	if C.getRet(resp) != C.RET_OK {
 		errMsg := C.GoStringN(C.getMyCharPtr(resp), C.int(C.getMyCharLen(resp)))
 		Error("error wakuNew for %s: %v", nodeName, errMsg)
 		return nil, errors.New(errMsg)
 	}
-
-	wg.Add(1)
-	n.wakuCtx = C.cGoWakuNew(cJsonConfig, resp)
-	wg.Wait()
 
 	n.MsgChan = make(chan common.Envelope, MsgChanBufferSize)
 	n.TopicHealthChan = make(chan topicHealth, TopicHealthChanBufferSize)


### PR DESCRIPTION
Fixing return value validation in `NewWakuNode ` and adding `NumShardsInNetwork` config so 0 is sent as a default (which means static sharding being used)

Issue: https://github.com/waku-org/nwaku/issues/3076