### PR TITLE
chore: use externally provided nwaku

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ waku/store.sqlite3-wal
 waku/test_repeated_start_stop.log
 
 third_party/
+
+# JetBrains IDEs
+.idea/

--- a/waku/Makefile
+++ b/waku/Makefile
@@ -1,7 +1,7 @@
 # Makefile for Waku Go Bindings
 
 # Directories
-THIRD_PARTY_DIR := ../third_party
+THIRD_PARTY_DIR := $(shell pwd)/../third_party
 NWAKU_REPO := https://github.com/waku-org/nwaku
 NWAKU_DIR := $(THIRD_PARTY_DIR)/nwaku
 
@@ -31,7 +31,10 @@ build-libwaku: prepare
 	@cd $(NWAKU_DIR) && make libwaku
 
 # Build Waku Go Bindings
-build: build-libwaku
+
+build: export CGO_CFLAGS = "-I${NWAKU_DIR}/library/"
+build: export CGO_LDFLAGS = "-L${NWAKU_DIR}/build/ -lwaku -L${NWAKU_DIR} -Wl,-rpath,${NWAKU_DIR}/build/"
+build:
 	@echo "Building Waku Go Bindings..."
 	go build ./...
 

--- a/waku/Makefile
+++ b/waku/Makefile
@@ -5,28 +5,13 @@ THIRD_PARTY_DIR := $(shell pwd)/../third_party
 NWAKU_REPO := https://github.com/waku-org/nwaku
 NWAKU_DIR := $(THIRD_PARTY_DIR)/nwaku
 
-.PHONY: all clean prepare build-libwaku build
+.PHONY: all clean build-libwaku build
 
 # Default target
 all: build
 
-# Prepare third_party directory and clone nwaku
-prepare:
-	@echo "Creating third_party directory..."
-	@mkdir -p $(THIRD_PARTY_DIR)
-
-	@echo "Cloning nwaku repository..."
-	@if [ ! -d "$(NWAKU_DIR)" ]; then \
-		cd $(THIRD_PARTY_DIR) && \
-		git clone $(NWAKU_REPO) && \
-		cd $(NWAKU_DIR) && \
-		make update; \
-	else \
-		echo "nwaku repository already exists."; \
-	fi
-
 # Build libwaku
-build-libwaku: prepare
+build-libwaku:
 	@echo "Building libwaku..."
 	@cd $(NWAKU_DIR) && make libwaku
 

--- a/waku/nwaku.go
+++ b/waku/nwaku.go
@@ -1,10 +1,7 @@
 package waku
 
 /*
-	#cgo LDFLAGS: -L../third_party/nwaku/build/ -lwaku
-	#cgo LDFLAGS: -L../third_party/nwaku -Wl,-rpath,../third_party/nwaku/build/
-
-	#include "../third_party/nwaku/library/libwaku.h"
+	#include "libwaku.h"
 	#include <stdio.h>
 	#include <stdlib.h>
 
@@ -348,6 +345,7 @@ import (
 	"github.com/multiformats/go-multiaddr"
 	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
 	"github.com/waku-org/go-waku/waku/v2/utils"
+
 	"github.com/waku-org/waku-go-bindings/waku/common"
 )
 


### PR DESCRIPTION
# Description

The main reason:
We want to [stop vendoring](https://github.com/status-im/status-go/pull/6951) in status-go. This means that `waku-go-bindings` will be located in go cache, e.g.:
```
/Users/sirotin/go/pkg/mod/github.com/waku-org/waku-go-bindings@v0.0.0-20250925081015-f78f4286cb37
```

And the current solution (manually cloning `nwaku`) requires the user to call `sudo mkdir thirdparty`, which is:
1. requires user interaction, so can't automate the whole process
2. a bit unfriendly, because we're asking for `sudo`

For a `vendor/.../third_party/nwaku`, we were able to avoid `sudo` (or only do it once).
But in the new case each developer would need to do it manually.

# Research

I looked into some projects that are Go-wrappers for C++ libraries.
- For small libraries like [sqlite](https://github.com/mattn/go-sqlite3), they include the source code (.c + .h files) right in the go repo
- For bigger projects (e.g. [opencv](https://github.com/hybridgroup/gocv), they expect the libraries to be installed in the system. And also say [how to run](https://gocv.io/getting-started/macos/#custom-environment) against a custom library build.

For other languages, a submodule is the optimal solution. But for Go, it doesn't work as it should. Because when you `go get .../waku-go-bindings`, you loose the `nwaku` submodule and have to dance with a tambourine to make it work.

# Approach

Each repository that uses `waku-go-bindings`, directly or indirectly, must provide `nwaku.h` and `libwaku.so`.
This would be done through `CGO_CFLAGS` and `CGO_LDFLAGS`.

The common approach would be to have `nwaku`  as a gitsubmodule and build it.

