### PR TITLE
fix test TestStressStoreQuery5kMessagesWithPagination (#70)

### DIFF
--- a/waku/stress_test.go
+++ b/waku/stress_test.go
@@ -99,9 +99,9 @@ func TestStressStoreQuery5kMessagesWithPagination(t *testing.T) {
 		hash, err := wakuNode.RelayPublishNoCTX(DefaultPubsubTopic, message)
 		require.NoError(t, err, "Failed to publish message")
 
-    err = node2.VerifyMessageReceived(message, hash)
+		err = node2.VerifyMessageReceived(message, hash)
 		require.NoError(t, err, "node2 failed to receive message %d", i)
-    err = wakuNode.VerifyMessageReceived(message, hash)
+		err = wakuNode.VerifyMessageReceived(message, hash)
 		require.NoError(t, err, "wakuNode failed to receive message %d", i)
 
 		if i%10 == 0 {


### PR DESCRIPTION
Fixes TestStressStoreQuery5kMessagesWithPagination in `waku/stress_test.go`.

Closes #70

EDIT: Just for context, the problem (or at least one of the problems) is that the message channel in the Go side needs to be pumped  by the test. This shows up only in stress tests that don't pump `WakuNode.msgChan` since they will fill up the channel to capacity (1024 messages).