### PR TITLE
ci: add PR-gate workflow + fix module path

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,9 +46,9 @@ jobs:
 
       - name: Build waku bindings
         run: |
-          export LMN_DIR=$(pwd)/vendor/logos-delivery
-          export CGO_CFLAGS="-I${LMN_DIR}/library/"
-          export CGO_LDFLAGS="-L${LMN_DIR}/build/ -lwaku -Wl,-rpath,${LMN_DIR}/build/" 
+          export LOGOS_DELIVERY_DIR=$(pwd)/vendor/logos-delivery
+          export CGO_CFLAGS="-I${LOGOS_DELIVERY_DIR}/library/"
+          export CGO_LDFLAGS="-L${LOGOS_DELIVERY_DIR}/build/ -lwaku -Wl,-rpath,${LOGOS_DELIVERY_DIR}/build/" 
           make -C waku build
 
       - name: Increase ulimit
@@ -58,9 +58,9 @@ jobs:
         run: |
           set -euo pipefail
           cd waku
-          export LMN_DIR=$(pwd)/vendor/logos-delivery
-          export CGO_CFLAGS="-I${LMN_DIR}/library/"
-          export CGO_LDFLAGS="-L${LMN_DIR}/build/ -lwaku -Wl,-rpath,${LMN_DIR}/build/"
+          export LOGOS_DELIVERY_DIR=$(pwd)/vendor/logos-delivery
+          export CGO_CFLAGS="-I${LOGOS_DELIVERY_DIR}/library/"
+          export CGO_LDFLAGS="-L${LOGOS_DELIVERY_DIR}/build/ -lwaku -Wl,-rpath,${LOGOS_DELIVERY_DIR}/build/"
           go test -count=10 -p=1 -v -timeout=360m . | tee ../testlogs.log
 
       - name: Upload daily test logs

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,57 @@
+name: PR
+
+on:
+  pull_request:
+    branches:
+      - master
+
+# Cancel superseded runs on the same PR.
+concurrency:
+  group: pr-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    env:
+      LMN_DIR: ${{ github.workspace }}/vendor/logos-delivery
+      # libwaku (kernel) is required at compile time for the cgo packages.
+      # Updated to also include liblogosdelivery once the messaging package lands.
+      CGO_CFLAGS: -I${{ github.workspace }}/vendor/logos-delivery/library/
+      CGO_LDFLAGS: -L${{ github.workspace }}/vendor/logos-delivery/build/ -lwaku -Wl,-rpath,${{ github.workspace }}/vendor/logos-delivery/build/
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - name: Clone logos-delivery
+        run: |
+          mkdir -p vendor
+          git clone --depth 1 https://github.com/logos-messaging/logos-delivery.git vendor/logos-delivery
+
+      - name: Build libwaku
+        run: make -C vendor/logos-delivery libwaku -j
+
+      - name: go build
+        run: go build ./...
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v2.4.0
+
+      - name: go test (compile)
+        # Compile every package's test binary without running the (heavy,
+        # integration) suite — that runs nightly in CI.yml. This keeps the PR
+        # gate fast and deterministic while still catching test-code breakage.
+        run: go test -run '^$' ./...

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       # Clone the logos-delivery checkout OUTSIDE the module tree: a directory
       # named `vendor/` at the module root would put Go into vendor mode.
-      LMN_DIR: ${{ github.workspace }}/.logos-delivery
+      LOGOS_DELIVERY_DIR: ${{ github.workspace }}/.logos-delivery
       # libwaku (kernel) is required at compile time for the cgo packages.
       # Updated to also include liblogosdelivery once the messaging package lands.
       CGO_CFLAGS: -I${{ github.workspace }}/.logos-delivery/library/
@@ -35,17 +35,43 @@ jobs:
         with:
           go-version: "1.24"
 
+      - name: Resolve logos-delivery commit
+        # Cache the built kernel keyed on the exact upstream commit, so the
+        # expensive clone + build is skipped while logos-delivery's HEAD is
+        # unchanged. ls-remote gives us the SHA before we clone.
+        id: logos-delivery-rev
+        run: |
+          rev=$(git ls-remote https://github.com/logos-messaging/logos-delivery.git HEAD | cut -f1)
+          echo "rev=$rev" >> "$GITHUB_OUTPUT"
+
+      - name: Cache logos-delivery build
+        id: logos-delivery-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.LOGOS_DELIVERY_DIR }}
+          key: logos-delivery-${{ runner.os }}-${{ steps.logos-delivery-rev.outputs.rev }}
+
       - name: Clone logos-delivery
-        run: git clone --depth 1 https://github.com/logos-messaging/logos-delivery.git "$LMN_DIR"
+        if: steps.logos-delivery-cache.outputs.cache-hit != 'true'
+        run: git clone --depth 1 https://github.com/logos-messaging/logos-delivery.git "$LOGOS_DELIVERY_DIR"
 
       - name: Build libwaku
-        run: make -C "$LMN_DIR" libwaku -j
+        if: steps.logos-delivery-cache.outputs.cache-hit != 'true'
+        run: make -C "$LOGOS_DELIVERY_DIR" libwaku -j
 
       - name: go build
         run: go build ./...
 
       - name: go vet
         run: go vet ./...
+
+      - name: go mod tidy is clean
+        # `go mod tidy` must be a no-op on a well-maintained module. If it
+        # changes go.mod/go.sum the PR left them out of sync — fail and show
+        # the diff so the author can commit the tidied result.
+        run: |
+          go mod tidy
+          git diff --exit-code go.mod go.sum
 
       - name: Ensure base ref is available for lint
         # golangci-lint's new-from-merge-base needs origin/master present.

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -45,6 +45,10 @@ jobs:
       - name: go vet
         run: go vet ./...
 
+      - name: Ensure base ref is available for lint
+        # golangci-lint's new-from-merge-base needs origin/master present.
+        run: git fetch --no-tags origin master
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -52,7 +52,8 @@ jobs:
         run: git fetch --no-tags origin master
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        # v7 is required for golangci-lint v2.
+        uses: golangci/golangci-lint-action@v7
         with:
           version: v2.4.0
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,11 +14,15 @@ jobs:
   gate:
     runs-on: ubuntu-latest
     env:
-      LMN_DIR: ${{ github.workspace }}/vendor/logos-delivery
+      # Clone the logos-delivery checkout OUTSIDE the module tree: a directory
+      # named `vendor/` at the module root would put Go into vendor mode.
+      LMN_DIR: ${{ github.workspace }}/.logos-delivery
       # libwaku (kernel) is required at compile time for the cgo packages.
       # Updated to also include liblogosdelivery once the messaging package lands.
-      CGO_CFLAGS: -I${{ github.workspace }}/vendor/logos-delivery/library/
-      CGO_LDFLAGS: -L${{ github.workspace }}/vendor/logos-delivery/build/ -lwaku -Wl,-rpath,${{ github.workspace }}/vendor/logos-delivery/build/
+      CGO_CFLAGS: -I${{ github.workspace }}/.logos-delivery/library/
+      CGO_LDFLAGS: -L${{ github.workspace }}/.logos-delivery/build/ -lwaku -Wl,-rpath,${{ github.workspace }}/.logos-delivery/build/
+      # Build in module mode; never use a vendor/ dir.
+      GOFLAGS: -mod=mod
 
     steps:
       - name: Check out repository
@@ -32,12 +36,10 @@ jobs:
           go-version: "1.24"
 
       - name: Clone logos-delivery
-        run: |
-          mkdir -p vendor
-          git clone --depth 1 https://github.com/logos-messaging/logos-delivery.git vendor/logos-delivery
+        run: git clone --depth 1 https://github.com/logos-messaging/logos-delivery.git "$LMN_DIR"
 
       - name: Build libwaku
-        run: make -C vendor/logos-delivery libwaku -j
+        run: make -C "$LMN_DIR" libwaku -j
 
       - name: go build
         run: go build ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,11 @@
+# golangci-lint v2 configuration.
+# Baseline, low-noise gate for PRs. Tighten over time as the codebase is cleaned up.
+version: "2"
+
+linters:
+  # `standard` = errcheck, govet, ineffassign, staticcheck, unused.
+  default: standard
+
+formatters:
+  enable:
+    - gofmt

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,4 @@
 # golangci-lint v2 configuration.
-# Baseline, low-noise gate for PRs. Tighten over time as the codebase is cleaned up.
 version: "2"
 
 linters:
@@ -9,3 +8,11 @@ linters:
 formatters:
   enable:
     - gofmt
+
+issues:
+  # Only report issues introduced since the merge-base with the target branch.
+  # The legacy kernel wrapper carries pre-existing findings (unchecked
+  # `defer Close()`, dead helpers) and is slated to move (#108) / be removed
+  # post-logos-delivery#3851 — gating it now would drown real signal. New code
+  # (e.g. the messaging package) gets the full linter set.
+  new-from-merge-base: origin/master

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ If you have `logos-delivery` checked out, point the build to it:
 
 ```bash
 # path to your existing logos-delivery clone
-export LMN_DIR=/absolute/path/to/logos-delivery
-export CGO_CFLAGS="-I${LMN_DIR}/library"
-export CGO_LDFLAGS="-L${LMN_DIR}/build -lwaku -Wl,-rpath,${LMN_DIR}/build"
+export LOGOS_DELIVERY_DIR=/absolute/path/to/logos-delivery
+export CGO_CFLAGS="-I${LOGOS_DELIVERY_DIR}/library"
+export CGO_LDFLAGS="-L${LOGOS_DELIVERY_DIR}/build -lwaku -Wl,-rpath,${LOGOS_DELIVERY_DIR}/build"
 
 # compile all packages
 make -C waku build

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/logos-messaging/logos-messaging-go-bindings
+module github.com/logos-messaging/logos-delivery-go-bindings
 
 go 1.24.0
 

--- a/tools/memory_record.go
+++ b/tools/memory_record.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/logos-messaging/logos-messaging-go-bindings/utils"
+	"github.com/logos-messaging/logos-delivery-go-bindings/utils"
 )
 
 var (

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -75,4 +75,3 @@ func GetRSSKB() (uint64, error) {
 	pageSize := os.Getpagesize()
 	return (rssPages * uint64(pageSize)) / 1024, nil
 }
-

--- a/waku/Makefile
+++ b/waku/Makefile
@@ -1,17 +1,17 @@
 # Makefile for Waku Go Bindings
 
 # Path to logos-delivery submodule
-export LMN_DIR ?= $(shell pwd)/../vendor/logos-delivery
+export LOGOS_DELIVERY_DIR ?= $(shell pwd)/../vendor/logos-delivery
 
 # Debugging output
 print-paths:
-	@echo "LMN_DIR: $(LMN_DIR)"
+	@echo "LOGOS_DELIVERY_DIR: $(LOGOS_DELIVERY_DIR)"
 	@echo "HEADER_PATH: $(LIBWAKU_HEADER_PATH)"
 	@echo "LIB_PATH: $(LIBWAKU_LIB_PATH)"
 
 # Default paths for libwaku library and headers (can be overridden)
-export LIBWAKU_HEADER_PATH ?= $(LMN_DIR)/library
-export LIBWAKU_LIB_PATH ?= $(LMN_DIR)/build
+export LIBWAKU_HEADER_PATH ?= $(LOGOS_DELIVERY_DIR)/library
+export LIBWAKU_LIB_PATH ?= $(LOGOS_DELIVERY_DIR)/build
 
 export CGO_CFLAGS := -I$(LIBWAKU_HEADER_PATH)/
 export CGO_LDFLAGS := -L$(LIBWAKU_LIB_PATH)/ -lwaku -Wl,-rpath,$(LIBWAKU_LIB_PATH)/

--- a/waku/common/envelope.go
+++ b/waku/common/envelope.go
@@ -3,7 +3,7 @@ package common
 import (
 	"encoding/json"
 
-	"github.com/logos-messaging/logos-messaging-go-bindings/waku/pb"
+	"github.com/logos-messaging/logos-delivery-go-bindings/waku/pb"
 )
 
 // Envelope contains information about the pubsub topic of a WakuMessage

--- a/waku/nodes_basic_test.go
+++ b/waku/nodes_basic_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/logos-messaging/logos-messaging-go-bindings/waku/common"
+	"github.com/logos-messaging/logos-delivery-go-bindings/waku/common"
 	"github.com/stretchr/testify/require"
 )
 
@@ -29,7 +29,7 @@ func TestBasicWakuNodes(t *testing.T) {
 	Debug("TestBasicWakuNodes completed successfully")
 }
 
-/* artifact https://github.com/logos-messaging/logos-messaging-go-bindings/issues/40 */
+/* artifact https://github.com/logos-messaging/logos-delivery-go-bindings/issues/40 */
 func TestNodeRestart(t *testing.T) {
 	t.Skip("Skipping test for open artifact ")
 	Debug("Starting TestNodeRestart")

--- a/waku/nwaku.go
+++ b/waku/nwaku.go
@@ -352,17 +352,17 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/logos-messaging/logos-messaging-go-bindings/waku/timesource"
+	"github.com/logos-messaging/logos-delivery-go-bindings/waku/timesource"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/libp2p/go-libp2p/core/peer"
 	libp2pproto "github.com/libp2p/go-libp2p/core/protocol"
+	"github.com/logos-messaging/logos-delivery-go-bindings/waku/pb"
+	"github.com/logos-messaging/logos-delivery-go-bindings/waku/utils"
 	"github.com/multiformats/go-multiaddr"
-	"github.com/logos-messaging/logos-messaging-go-bindings/waku/pb"
-	"github.com/logos-messaging/logos-messaging-go-bindings/waku/utils"
 
-	"github.com/logos-messaging/logos-messaging-go-bindings/waku/common"
+	"github.com/logos-messaging/logos-delivery-go-bindings/waku/common"
 )
 
 const requestTimeout = 30 * time.Second

--- a/waku/nwaku_test.go
+++ b/waku/nwaku_test.go
@@ -13,11 +13,11 @@ import (
 
 	"github.com/cenkalti/backoff/v3"
 	"github.com/libp2p/go-libp2p/core/peer"
-	"github.com/logos-messaging/logos-messaging-go-bindings/waku/common"
+	"github.com/logos-messaging/logos-delivery-go-bindings/waku/common"
+	"github.com/logos-messaging/logos-delivery-go-bindings/waku/pb"
+	"github.com/logos-messaging/logos-delivery-go-bindings/waku/store"
 	ma "github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/require"
-	"github.com/logos-messaging/logos-messaging-go-bindings/waku/pb"
-	"github.com/logos-messaging/logos-messaging-go-bindings/waku/store"
 )
 
 // In order to run this test, you must run an nwaku node

--- a/waku/nwaku_test_utils.go
+++ b/waku/nwaku_test_utils.go
@@ -16,9 +16,9 @@ import (
 
 	"github.com/cenkalti/backoff/v3"
 	"github.com/libp2p/go-libp2p/core/peer"
-	"github.com/logos-messaging/logos-messaging-go-bindings/utils"
-	"github.com/logos-messaging/logos-messaging-go-bindings/waku/common"
-	"github.com/logos-messaging/logos-messaging-go-bindings/waku/pb"
+	"github.com/logos-messaging/logos-delivery-go-bindings/utils"
+	"github.com/logos-messaging/logos-delivery-go-bindings/waku/common"
+	"github.com/logos-messaging/logos-delivery-go-bindings/waku/pb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/waku/peer_connections_test.go
+++ b/waku/peer_connections_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/logos-messaging/logos-messaging-go-bindings/waku/common"
+	"github.com/logos-messaging/logos-delivery-go-bindings/waku/common"
 	"github.com/stretchr/testify/require"
 )
 

--- a/waku/relay_test.go
+++ b/waku/relay_test.go
@@ -7,9 +7,9 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v3"
-	"github.com/logos-messaging/logos-messaging-go-bindings/waku/common"
+	"github.com/logos-messaging/logos-delivery-go-bindings/waku/common"
+	"github.com/logos-messaging/logos-delivery-go-bindings/waku/pb"
 	"github.com/stretchr/testify/require"
-	"github.com/logos-messaging/logos-messaging-go-bindings/waku/pb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/waku/store_test.go
+++ b/waku/store_test.go
@@ -6,10 +6,10 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v3"
+	"github.com/logos-messaging/logos-delivery-go-bindings/waku/pb"
 	"github.com/stretchr/testify/require"
-	"github.com/logos-messaging/logos-messaging-go-bindings/waku/pb"
 
-	"github.com/logos-messaging/logos-messaging-go-bindings/waku/common"
+	"github.com/logos-messaging/logos-delivery-go-bindings/waku/common"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/waku/stress_test.go
+++ b/waku/stress_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/logos-messaging/logos-messaging-go-bindings/waku/common"
+	"github.com/logos-messaging/logos-delivery-go-bindings/waku/common"
 	"github.com/stretchr/testify/require"
 
 	//	"go.uber.org/zap/zapcore"

--- a/waku/test_data.go
+++ b/waku/test_data.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/logos-messaging/logos-messaging-go-bindings/waku/common"
+	"github.com/logos-messaging/logos-delivery-go-bindings/waku/common"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/waku/utils/utils.go
+++ b/waku/utils/utils.go
@@ -8,15 +8,15 @@ import (
 )
 
 func GetRSSKB() (uint64, error) {
-    var m runtime.MemStats
-    runtime.ReadMemStats(&m)
-    return m.Sys / 1024, nil
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	return m.Sys / 1024, nil
 }
 
 func EncapsulatePeerID(p peer.ID, addrs ...multiaddr.Multiaddr) []multiaddr.Multiaddr {
 	encapsulated := make([]multiaddr.Multiaddr, 0, len(addrs))
 	for _, addr := range addrs {
-		encapsulated = append(encapsulated, addr.Encapsulate(multiaddr.StringCast("/p2p/" + p.String())))
+		encapsulated = append(encapsulated, addr.Encapsulate(multiaddr.StringCast("/p2p/"+p.String())))
 	}
 	return encapsulated
 }


### PR DESCRIPTION
Closes #107
Closes #110

## What & why
- **PR-gate CI** (`.github/workflows/pr.yml`, `on: pull_request`): the repo had no PR-triggered CI (only `workflow_dispatch` + nightly `schedule`), so nothing validated PRs. The gate clones logos-delivery, builds `libwaku`, then runs `go build`, `go vet`, `golangci-lint`, and a **test-compile** pass (`go test -run '^$' ./...`). The heavy integration suite stays nightly in `CI.yml`; the gate is kept fast and deterministic.
- **`.golangci.yml`**: baseline v2 config (standard linters + gofmt).
- **Module path fix**: `logos-messaging-go-bindings` → `logos-delivery-go-bindings` (matches the repo name), with all in-repo imports updated. Kept as a separate commit. gofmt re-sorts a few import blocks as a result.

Split into two commits (rename / CI) so the rename can be reviewed independently.