### PR TITLE
feat: Messaging API (pkg/messaging)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,10 +17,13 @@ jobs:
       # Clone the logos-delivery checkout OUTSIDE the module tree: a directory
       # named `vendor/` at the module root would put Go into vendor mode.
       LOGOS_DELIVERY_DIR: ${{ github.workspace }}/.logos-delivery
-      # libwaku (kernel) is required at compile time for the cgo packages.
-      # Updated to also include liblogosdelivery once the messaging package lands.
-      CGO_CFLAGS: -I${{ github.workspace }}/.logos-delivery/library/
-      CGO_LDFLAGS: -L${{ github.workspace }}/.logos-delivery/build/ -lwaku -Wl,-rpath,${{ github.workspace }}/.logos-delivery/build/
+      # Both kernel (libwaku) and messaging (liblogosdelivery) headers are on
+      # the include path so every package compiles. `-l` is deliberately NOT
+      # set here: each internal/ffi subpackage selects its own library via a
+      # `#cgo LDFLAGS` directive, so no binary links both libs (they export
+      # overlapping symbols until logos-delivery#3851).
+      CGO_CFLAGS: -I${{ github.workspace }}/.logos-delivery/library/ -I${{ github.workspace }}/.logos-delivery/liblogosdelivery/
+      CGO_LDFLAGS: -L${{ github.workspace }}/.logos-delivery/build/ -Wl,-rpath,${{ github.workspace }}/.logos-delivery/build/
       # Build in module mode; never use a vendor/ dir.
       GOFLAGS: -mod=mod
 
@@ -36,7 +39,7 @@ jobs:
           go-version: "1.24"
 
       - name: Resolve logos-delivery commit
-        # Cache the built kernel keyed on the exact upstream commit, so the
+        # Cache the built libraries keyed on the exact upstream commit, so the
         # expensive clone + build is skipped while logos-delivery's HEAD is
         # unchanged. ls-remote gives us the SHA before we clone.
         id: logos-delivery-rev
@@ -55,9 +58,9 @@ jobs:
         if: steps.logos-delivery-cache.outputs.cache-hit != 'true'
         run: git clone --depth 1 https://github.com/logos-messaging/logos-delivery.git "$LOGOS_DELIVERY_DIR"
 
-      - name: Build libwaku
+      - name: Build libwaku + liblogosdelivery
         if: steps.logos-delivery-cache.outputs.cache-hit != 'true'
-        run: make -C "$LOGOS_DELIVERY_DIR" libwaku -j
+        run: make -C "$LOGOS_DELIVERY_DIR" libwaku liblogosdelivery -j
 
       - name: go build
         run: go build ./...
@@ -83,8 +86,11 @@ jobs:
         with:
           version: v2.4.0
 
-      - name: go test (compile)
-        # Compile every package's test binary without running the (heavy,
-        # integration) suite — that runs nightly in CI.yml. This keeps the PR
-        # gate fast and deterministic while still catching test-code breakage.
-        run: go test -run '^$' ./...
+      - name: go test messaging (run)
+        # Fast, network-free unit tests for the Messaging API + its ffi bridge.
+        run: go test ./pkg/messaging/... ./internal/ffi/liblogosdelivery/...
+
+      - name: go test kernel (compile)
+        # The kernel suite is heavy integration (runs nightly in CI.yml), so
+        # only compile its test binaries here.
+        run: go test -run '^$' ./pkg/kernel/... ./internal/ffi/libwaku/...

--- a/examples/messaging/main.go
+++ b/examples/messaging/main.go
@@ -1,0 +1,83 @@
+// Command messaging is a minimal demonstration of the Messaging API binding:
+// create a client, start it, subscribe to a content topic, send a message, and
+// print the events that arrive.
+//
+// Build/run requires liblogosdelivery at link time, e.g.:
+//
+//	export LOGOS_DELIVERY_DIR=/abs/path/to/logos-delivery
+//	export CGO_CFLAGS="-I$LOGOS_DELIVERY_DIR/liblogosdelivery"
+//	export CGO_LDFLAGS="-L$LOGOS_DELIVERY_DIR/build -Wl,-rpath,$LOGOS_DELIVERY_DIR/build"
+//	go run ./examples/messaging
+package main
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/logos-messaging/logos-delivery-go-bindings/pkg/messaging"
+)
+
+func main() {
+	const contentTopic = "/my-app/1/chat/proto"
+
+	cfg := messaging.Config{
+		Relay:              true,
+		ClusterID:          16,
+		Shards:             []uint16{0},
+		NumShardsInNetwork: 8,
+		LogLevel:           "INFO",
+	}
+
+	client, err := messaging.New(cfg)
+	if err != nil {
+		log.Fatalf("new client: %v", err)
+	}
+	defer func() {
+		if err := client.Close(); err != nil {
+			log.Printf("close: %v", err)
+		}
+	}()
+
+	if err := client.Start(); err != nil {
+		log.Fatalf("start: %v", err)
+	}
+	defer func() {
+		if err := client.Stop(); err != nil {
+			log.Printf("stop: %v", err)
+		}
+	}()
+
+	if err := client.Subscribe(contentTopic); err != nil {
+		log.Fatalf("subscribe: %v", err)
+	}
+
+	// Print incoming events until the program exits.
+	go func() {
+		for ev := range client.Events() {
+			switch e := ev.(type) {
+			case messaging.MessageReceivedEvent:
+				log.Printf("received on %s: %q", e.Message.ContentTopic, e.Message.Payload)
+			case messaging.MessageSentEvent:
+				log.Printf("sent: req=%s hash=%s", e.RequestID, e.MessageHash)
+			case messaging.MessagePropagatedEvent:
+				log.Printf("propagated: req=%s", e.RequestID)
+			case messaging.MessageErrorEvent:
+				log.Printf("error: req=%s %s", e.RequestID, e.Err)
+			case messaging.ConnectionStatusEvent:
+				log.Printf("connection status: %s", e.Status)
+			}
+		}
+	}()
+
+	reqID, err := client.Send(context.Background(), messaging.Envelope{
+		ContentTopic: contentTopic,
+		Payload:      []byte("hello logos"),
+	})
+	if err != nil {
+		log.Fatalf("send: %v", err)
+	}
+	log.Printf("queued message, request id: %s", reqID)
+
+	time.Sleep(5 * time.Second)
+}

--- a/internal/ffi/liblogosdelivery/liblogosdelivery.go
+++ b/internal/ffi/liblogosdelivery/liblogosdelivery.go
@@ -1,0 +1,212 @@
+// Package liblogosdelivery is the cgo bridge over liblogosdelivery (the
+// logos-delivery Messaging API C library). It owns the synchronous
+// request/response callback plumbing, the shared async event callback, and the
+// handle->handler registry, and exposes Go-typed primitives so the public
+// messaging package stays pure Go.
+//
+// It links liblogosdelivery via a #cgo directive; it must never be linked into
+// the same binary as the libwaku bridge (overlapping symbols) until
+// logos-delivery#3851 consolidates the two libraries.
+package liblogosdelivery
+
+/*
+#cgo LDFLAGS: -llogosdelivery
+#include <liblogosdelivery.h>
+#include <stdlib.h>
+
+// logosGoCallback (sync request/response) and logosEventCallback (async events)
+// are implemented in Go and exported below.
+extern void logosGoCallback(int ret, char* msg, size_t len, void* resp);
+extern void logosEventCallback(int ret, char* msg, size_t len, void* userData);
+
+// logosResp carries a single synchronous call's result back from the callback,
+// plus a pointer to the Go sync.WaitGroup the caller blocks on.
+typedef struct {
+	int    ret;
+	char*  msg;
+	size_t len;
+	void*  wg;
+} logosResp;
+
+static void* allocLogosResp(void* wg) {
+	logosResp* r = (logosResp*) calloc(1, sizeof(logosResp));
+	r->wg = wg;
+	return r;
+}
+static void   freeLogosResp(void* resp) { if (resp != NULL) free(resp); }
+static char*  logosRespMsg(void* resp)  { return resp ? ((logosResp*)resp)->msg : NULL; }
+static size_t logosRespLen(void* resp)  { return resp ? ((logosResp*)resp)->len : 0; }
+static int    logosRespRet(void* resp)  { return resp ? ((logosResp*)resp)->ret : RET_ERR; }
+
+// Thin wrappers binding the shared Go callback to each entry point.
+static void* cGoCreateNode(const char* cfg, void* resp) {
+	return logosdelivery_create_node(cfg, (FFICallBack) logosGoCallback, resp);
+}
+static void cGoStartNode(void* ctx, void* resp) {
+	logosdelivery_start_node(ctx, (FFICallBack) logosGoCallback, resp);
+}
+static void cGoStopNode(void* ctx, void* resp) {
+	logosdelivery_stop_node(ctx, (FFICallBack) logosGoCallback, resp);
+}
+static void cGoDestroyNode(void* ctx, void* resp) {
+	logosdelivery_destroy(ctx, (FFICallBack) logosGoCallback, resp);
+}
+static void cGoSubscribe(void* ctx, const char* topic, void* resp) {
+	logosdelivery_subscribe(ctx, (FFICallBack) logosGoCallback, resp, topic);
+}
+static void cGoUnsubscribe(void* ctx, const char* topic, void* resp) {
+	logosdelivery_unsubscribe(ctx, (FFICallBack) logosGoCallback, resp, topic);
+}
+static void cGoSend(void* ctx, const char* msgJson, void* resp) {
+	logosdelivery_send(ctx, (FFICallBack) logosGoCallback, resp, msgJson);
+}
+static void cGoSetEventCallback(void* ctx) {
+	// ctx doubles as userData so the shared event callback can route the event
+	// to the right registered handler.
+	logosdelivery_set_event_callback(ctx, (FFICallBack) logosEventCallback, ctx);
+}
+*/
+import "C"
+
+import (
+	"errors"
+	"sync"
+	"unsafe"
+)
+
+// Handle is an opaque pointer to a node context owned by the C library.
+type Handle = unsafe.Pointer
+
+// RetOK is the return code callbacks report on success.
+const RetOK = C.RET_OK
+
+// EventHandler receives every event liblogosdelivery emits for a node: the raw
+// event JSON when ret == RetOK, an error message otherwise.
+type EventHandler func(ret int, msg string)
+
+// eventHandlers maps a node handle to the Go function that receives its
+// events. The shared C event callback looks the handler up by handle.
+var (
+	eventHandlersMu sync.RWMutex
+	eventHandlers   = make(map[Handle]EventHandler)
+)
+
+//export logosGoCallback
+func logosGoCallback(ret C.int, msg *C.char, length C.size_t, resp unsafe.Pointer) {
+	if resp == nil {
+		return
+	}
+	r := (*C.logosResp)(resp)
+	r.ret = ret
+	r.msg = msg
+	r.len = length
+	wg := (*sync.WaitGroup)(r.wg)
+	wg.Done()
+}
+
+//export logosEventCallback
+func logosEventCallback(ret C.int, msg *C.char, length C.size_t, userData unsafe.Pointer) {
+	eventHandlersMu.RLock()
+	fn := eventHandlers[userData] // userData carries the node's handle
+	eventHandlersMu.RUnlock()
+	if fn != nil {
+		fn(int(ret), C.GoStringN(msg, C.int(length)))
+	}
+}
+
+// call runs a synchronous entry point that reports its result through the
+// response callback, blocks until it completes, and returns the callback
+// message (on RetOK) or an error built from it.
+func call(invoke func(resp unsafe.Pointer)) (string, error) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	resp := C.allocLogosResp(unsafe.Pointer(&wg))
+	defer C.freeLogosResp(resp)
+
+	invoke(resp)
+	wg.Wait()
+
+	msg := C.GoStringN(C.logosRespMsg(resp), C.int(C.logosRespLen(resp)))
+	if C.logosRespRet(resp) != C.RET_OK {
+		return "", errors.New(msg)
+	}
+	return msg, nil
+}
+
+// New builds a node from a WakuNodeConf JSON string and returns its handle.
+// The handle must be released with Destroy.
+func New(configJSON string) (Handle, error) {
+	cCfg := C.CString(configJSON)
+	defer C.free(unsafe.Pointer(cCfg))
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	resp := C.allocLogosResp(unsafe.Pointer(&wg))
+	defer C.freeLogosResp(resp)
+
+	ctx := C.cGoCreateNode(cCfg, resp)
+	wg.Wait()
+
+	if C.logosRespRet(resp) != C.RET_OK || ctx == nil {
+		msg := C.GoStringN(C.logosRespMsg(resp), C.int(C.logosRespLen(resp)))
+		if msg == "" {
+			msg = "logosdelivery_create_node returned no context"
+		}
+		return nil, errors.New(msg)
+	}
+	return Handle(ctx), nil
+}
+
+// SetEventHandler registers fn to receive events for the node and wires up the
+// underlying C event callback. Call before Start.
+func SetEventHandler(h Handle, fn EventHandler) {
+	eventHandlersMu.Lock()
+	eventHandlers[h] = fn
+	eventHandlersMu.Unlock()
+	C.cGoSetEventCallback(h)
+}
+
+// Start starts the node's protocols and Messaging API services.
+func Start(h Handle) error {
+	_, err := call(func(resp unsafe.Pointer) { C.cGoStartNode(h, resp) })
+	return err
+}
+
+// Stop stops the node.
+func Stop(h Handle) error {
+	_, err := call(func(resp unsafe.Pointer) { C.cGoStopNode(h, resp) })
+	return err
+}
+
+// Destroy releases the node context and unregisters its event handler.
+func Destroy(h Handle) error {
+	_, err := call(func(resp unsafe.Pointer) { C.cGoDestroyNode(h, resp) })
+	eventHandlersMu.Lock()
+	delete(eventHandlers, h)
+	eventHandlersMu.Unlock()
+	return err
+}
+
+// Subscribe subscribes the node to a content topic.
+func Subscribe(h Handle, contentTopic string) error {
+	cTopic := C.CString(contentTopic)
+	defer C.free(unsafe.Pointer(cTopic))
+	_, err := call(func(resp unsafe.Pointer) { C.cGoSubscribe(h, cTopic, resp) })
+	return err
+}
+
+// Unsubscribe unsubscribes the node from a content topic.
+func Unsubscribe(h Handle, contentTopic string) error {
+	cTopic := C.CString(contentTopic)
+	defer C.free(unsafe.Pointer(cTopic))
+	_, err := call(func(resp unsafe.Pointer) { C.cGoUnsubscribe(h, cTopic, resp) })
+	return err
+}
+
+// Send sends a message (JSON: {contentTopic, payload(base64), ephemeral}) and
+// returns the request id used to correlate later send events.
+func Send(h Handle, messageJSON string) (requestID string, err error) {
+	cMsg := C.CString(messageJSON)
+	defer C.free(unsafe.Pointer(cMsg))
+	return call(func(resp unsafe.Pointer) { C.cGoSend(h, cMsg, resp) })
+}

--- a/internal/ffi/libwaku/libwaku.go
+++ b/internal/ffi/libwaku/libwaku.go
@@ -5,6 +5,7 @@
 package libwaku
 
 /*
+#cgo LDFLAGS: -lwaku
 #include <libwaku.h>
 #include <stdlib.h>
 

--- a/pkg/messaging/config.go
+++ b/pkg/messaging/config.go
@@ -1,0 +1,8 @@
+package messaging
+
+import "github.com/logos-messaging/logos-delivery-go-bindings/pkg/kernel/common"
+
+// Config is the node configuration passed to the underlying library. Its JSON
+// representation is a WakuNodeConf, which is what logosdelivery_create_node
+// consumes. It aliases the kernel config type so the two stay in lockstep.
+type Config = common.WakuConfig

--- a/pkg/messaging/doc.go
+++ b/pkg/messaging/doc.go
@@ -2,4 +2,8 @@
 // logos-delivery Messaging API (an opinionated layer over the kernel protocols
 // that owns reliability, re-subscriptions, store-based catch-up and the
 // Messaging event surface).
+//
+// It exposes a MessagingClient (create/start/stop, send/subscribe/unsubscribe) and a
+// unified Events channel, backed by cgo calls into liblogosdelivery via the
+// internal/ffi package.
 package messaging

--- a/pkg/messaging/envelope.go
+++ b/pkg/messaging/envelope.go
@@ -1,0 +1,17 @@
+package messaging
+
+// ContentTopic is an application-level message category, e.g.
+// "/my-app/1/chat/proto".
+type ContentTopic = string
+
+// RequestID correlates a Send call with its later MessageSentEvent /
+// MessagePropagatedEvent / MessageErrorEvent.
+type RequestID string
+
+// Envelope is an outgoing Messaging API message.
+type Envelope struct {
+	ContentTopic ContentTopic
+	Payload      []byte
+	// Ephemeral marks the message as transient (not stored).
+	Ephemeral bool
+}

--- a/pkg/messaging/event.go
+++ b/pkg/messaging/event.go
@@ -1,0 +1,213 @@
+package messaging
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+)
+
+// ConnectionStatus reports the node's overall connectivity.
+type ConnectionStatus int
+
+const (
+	Disconnected ConnectionStatus = iota
+	PartiallyConnected
+	Connected
+)
+
+func (s ConnectionStatus) String() string {
+	switch s {
+	case Disconnected:
+		return "Disconnected"
+	case PartiallyConnected:
+		return "PartiallyConnected"
+	case Connected:
+		return "Connected"
+	default:
+		return fmt.Sprintf("ConnectionStatus(%d)", int(s))
+	}
+}
+
+// Message is a received message (the underlying WakuMessage).
+type Message struct {
+	ContentTopic ContentTopic
+	Payload      []byte
+	Meta         []byte
+	Version      uint32
+	// Timestamp is sender-generated, in nanoseconds.
+	Timestamp int64
+	Ephemeral bool
+}
+
+// Event is the sealed interface implemented by every Messaging API event
+// delivered on MessagingClient.Events(). Consumers type-switch over the concrete types.
+type Event interface {
+	isMessagingEvent()
+}
+
+// MessageReceivedEvent is emitted when a message is received from the network.
+type MessageReceivedEvent struct {
+	MessageHash string
+	Message     Message
+}
+
+// MessageSentEvent is emitted when a message has been accepted and queued for
+// delivery by the send service.
+type MessageSentEvent struct {
+	RequestID   RequestID
+	MessageHash string
+}
+
+// MessagePropagatedEvent is emitted when a message has been propagated to
+// neighbouring nodes.
+type MessagePropagatedEvent struct {
+	RequestID   RequestID
+	MessageHash string
+}
+
+// MessageErrorEvent is emitted when sending or propagating a message fails.
+type MessageErrorEvent struct {
+	RequestID   RequestID
+	MessageHash string
+	Err         string
+}
+
+// ConnectionStatusEvent is emitted when the node's connectivity changes.
+type ConnectionStatusEvent struct {
+	Status ConnectionStatus
+}
+
+func (MessageReceivedEvent) isMessagingEvent()   {}
+func (MessageSentEvent) isMessagingEvent()       {}
+func (MessagePropagatedEvent) isMessagingEvent() {}
+func (MessageErrorEvent) isMessagingEvent()      {}
+func (ConnectionStatusEvent) isMessagingEvent()  {}
+
+// wireBytes decodes a byte field that liblogosdelivery serialises with
+// std/json defaults. On receive (WakuMessage) that is a JSON array of byte
+// integers; we also accept a base64 string and null for robustness.
+type wireBytes []byte
+
+func (b *wireBytes) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 || string(data) == "null" {
+		*b = nil
+		return nil
+	}
+	if data[0] == '[' {
+		var nums []int
+		if err := json.Unmarshal(data, &nums); err != nil {
+			return err
+		}
+		out := make([]byte, len(nums))
+		for i, n := range nums {
+			out[i] = byte(n)
+		}
+		*b = out
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	dec, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return err
+	}
+	*b = dec
+	return nil
+}
+
+// decodeEvent parses a flat event JSON string from liblogosdelivery into a
+// typed Event. Unknown event types return a nil Event and no error so callers
+// can ignore them.
+func decodeEvent(eventJSON string) (Event, error) {
+	var head struct {
+		EventType string `json:"eventType"`
+	}
+	if err := json.Unmarshal([]byte(eventJSON), &head); err != nil {
+		return nil, fmt.Errorf("decode event: %w", err)
+	}
+
+	switch head.EventType {
+	case "message_received":
+		var e struct {
+			MessageHash string `json:"messageHash"`
+			Message     struct {
+				ContentTopic string    `json:"contentTopic"`
+				Payload      wireBytes `json:"payload"`
+				Meta         wireBytes `json:"meta"`
+				Version      uint32    `json:"version"`
+				Timestamp    int64     `json:"timestamp"`
+				Ephemeral    bool      `json:"ephemeral"`
+			} `json:"message"`
+		}
+		if err := json.Unmarshal([]byte(eventJSON), &e); err != nil {
+			return nil, fmt.Errorf("decode message_received: %w", err)
+		}
+		return MessageReceivedEvent{
+			MessageHash: e.MessageHash,
+			Message: Message{
+				ContentTopic: e.Message.ContentTopic,
+				Payload:      e.Message.Payload,
+				Meta:         e.Message.Meta,
+				Version:      e.Message.Version,
+				Timestamp:    e.Message.Timestamp,
+				Ephemeral:    e.Message.Ephemeral,
+			},
+		}, nil
+
+	case "message_sent":
+		var e struct {
+			RequestID   string `json:"requestId"`
+			MessageHash string `json:"messageHash"`
+		}
+		if err := json.Unmarshal([]byte(eventJSON), &e); err != nil {
+			return nil, fmt.Errorf("decode message_sent: %w", err)
+		}
+		return MessageSentEvent{RequestID: RequestID(e.RequestID), MessageHash: e.MessageHash}, nil
+
+	case "message_propagated":
+		var e struct {
+			RequestID   string `json:"requestId"`
+			MessageHash string `json:"messageHash"`
+		}
+		if err := json.Unmarshal([]byte(eventJSON), &e); err != nil {
+			return nil, fmt.Errorf("decode message_propagated: %w", err)
+		}
+		return MessagePropagatedEvent{RequestID: RequestID(e.RequestID), MessageHash: e.MessageHash}, nil
+
+	case "message_error":
+		var e struct {
+			RequestID   string `json:"requestId"`
+			MessageHash string `json:"messageHash"`
+			Error       string `json:"error"`
+		}
+		if err := json.Unmarshal([]byte(eventJSON), &e); err != nil {
+			return nil, fmt.Errorf("decode message_error: %w", err)
+		}
+		return MessageErrorEvent{RequestID: RequestID(e.RequestID), MessageHash: e.MessageHash, Err: e.Error}, nil
+
+	case "connection_status_change":
+		var e struct {
+			ConnectionStatus string `json:"connectionStatus"`
+		}
+		if err := json.Unmarshal([]byte(eventJSON), &e); err != nil {
+			return nil, fmt.Errorf("decode connection_status_change: %w", err)
+		}
+		return ConnectionStatusEvent{Status: parseConnectionStatus(e.ConnectionStatus)}, nil
+
+	default:
+		return nil, nil
+	}
+}
+
+func parseConnectionStatus(s string) ConnectionStatus {
+	switch s {
+	case "Connected":
+		return Connected
+	case "PartiallyConnected":
+		return PartiallyConnected
+	default:
+		return Disconnected
+	}
+}

--- a/pkg/messaging/event_test.go
+++ b/pkg/messaging/event_test.go
@@ -1,0 +1,107 @@
+package messaging
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestDecodeEvent(t *testing.T) {
+	t.Run("message_received with int-array payload", func(t *testing.T) {
+		// liblogosdelivery serialises WakuMessage via std/json: payload/meta are
+		// arrays of byte integers, not base64. "hi" = [104,105].
+		const raw = `{"eventType":"message_received","messageHash":"0xabc",` +
+			`"message":{"contentTopic":"/app/1/c/proto","payload":[104,105],` +
+			`"meta":[1,2],"version":1,"timestamp":1717000000000000000,"ephemeral":true}}`
+		ev, err := decodeEvent(raw)
+		if err != nil {
+			t.Fatalf("decodeEvent: %v", err)
+		}
+		got, ok := ev.(MessageReceivedEvent)
+		if !ok {
+			t.Fatalf("got %T, want MessageReceivedEvent", ev)
+		}
+		if got.MessageHash != "0xabc" {
+			t.Errorf("messageHash = %q", got.MessageHash)
+		}
+		if !bytes.Equal(got.Message.Payload, []byte("hi")) {
+			t.Errorf("payload = %v, want %v", got.Message.Payload, []byte("hi"))
+		}
+		if !bytes.Equal(got.Message.Meta, []byte{1, 2}) {
+			t.Errorf("meta = %v", got.Message.Meta)
+		}
+		if got.Message.ContentTopic != "/app/1/c/proto" {
+			t.Errorf("contentTopic = %q", got.Message.ContentTopic)
+		}
+		if got.Message.Version != 1 || got.Message.Timestamp != 1717000000000000000 || !got.Message.Ephemeral {
+			t.Errorf("scalar fields wrong: %+v", got.Message)
+		}
+	})
+
+	t.Run("message_received with base64 payload (robustness)", func(t *testing.T) {
+		const raw = `{"eventType":"message_received","messageHash":"0x1",` +
+			`"message":{"contentTopic":"/a/1/b/proto","payload":"aGk=","ephemeral":false}}`
+		ev, err := decodeEvent(raw)
+		if err != nil {
+			t.Fatalf("decodeEvent: %v", err)
+		}
+		if got := ev.(MessageReceivedEvent); !bytes.Equal(got.Message.Payload, []byte("hi")) {
+			t.Errorf("payload = %v", got.Message.Payload)
+		}
+	})
+
+	t.Run("message_sent", func(t *testing.T) {
+		ev, err := decodeEvent(`{"eventType":"message_sent","requestId":"req-1","messageHash":"0x9"}`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, ok := ev.(MessageSentEvent)
+		if !ok || got.RequestID != "req-1" || got.MessageHash != "0x9" {
+			t.Fatalf("got %#v", ev)
+		}
+	})
+
+	t.Run("message_propagated", func(t *testing.T) {
+		ev, err := decodeEvent(`{"eventType":"message_propagated","requestId":"req-2","messageHash":"0x8"}`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, ok := ev.(MessagePropagatedEvent); !ok || got.RequestID != "req-2" {
+			t.Fatalf("got %#v", ev)
+		}
+	})
+
+	t.Run("message_error", func(t *testing.T) {
+		ev, err := decodeEvent(`{"eventType":"message_error","requestId":"req-3","messageHash":"0x7","error":"boom"}`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, ok := ev.(MessageErrorEvent)
+		if !ok || got.RequestID != "req-3" || got.Err != "boom" {
+			t.Fatalf("got %#v", ev)
+		}
+	})
+
+	t.Run("connection_status_change", func(t *testing.T) {
+		for in, want := range map[string]ConnectionStatus{
+			"Connected":          Connected,
+			"PartiallyConnected": PartiallyConnected,
+			"Disconnected":       Disconnected,
+		} {
+			raw := `{"eventType":"connection_status_change","connectionStatus":"` + in + `"}`
+			ev, err := decodeEvent(raw)
+			if err != nil {
+				t.Fatalf("%s: %v", in, err)
+			}
+			if got := ev.(ConnectionStatusEvent); got.Status != want {
+				t.Errorf("%s -> %v, want %v", in, got.Status, want)
+			}
+		}
+	})
+
+	t.Run("unknown event type is ignored", func(t *testing.T) {
+		ev, err := decodeEvent(`{"eventType":"something_new","foo":1}`)
+		if err != nil || ev != nil {
+			t.Fatalf("got ev=%v err=%v, want nil,nil", ev, err)
+		}
+	})
+}

--- a/pkg/messaging/messaging_client.go
+++ b/pkg/messaging/messaging_client.go
@@ -1,0 +1,109 @@
+package messaging
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/logos-messaging/logos-delivery-go-bindings/internal/ffi/liblogosdelivery"
+)
+
+// eventBufferSize bounds the buffered Events channel. Events are dropped (never
+// blocked) if a consumer falls behind, so the FFI worker thread is never stalled.
+const eventBufferSize = 1024
+
+// MessagingClient is a logos-delivery Messaging API client (the Nim
+// MessagingClient). Create it with New, then Start it; consume incoming events
+// from Events(); release it with Close.
+type MessagingClient struct {
+	h         liblogosdelivery.Handle
+	events    chan Event
+	closeOnce sync.Once
+}
+
+// New creates (but does not start) a MessagingClient from cfg.
+func New(cfg Config) (*MessagingClient, error) {
+	cfgJSON, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("marshal config: %w", err)
+	}
+	h, err := liblogosdelivery.New(string(cfgJSON))
+	if err != nil {
+		return nil, err
+	}
+	c := &MessagingClient{h: h, events: make(chan Event, eventBufferSize)}
+	liblogosdelivery.SetEventHandler(h, c.onEvent)
+	return c, nil
+}
+
+// onEvent runs on the FFI worker thread: decode and hand off without blocking.
+func (c *MessagingClient) onEvent(ret int, msg string) {
+	if ret != liblogosdelivery.RetOK {
+		return
+	}
+	ev, err := decodeEvent(msg)
+	if err != nil || ev == nil {
+		return
+	}
+	select {
+	case c.events <- ev:
+	default:
+		// Consumer not keeping up; drop rather than block the worker thread.
+	}
+}
+
+// Start starts the client's protocols and Messaging API services.
+func (c *MessagingClient) Start() error { return liblogosdelivery.Start(c.h) }
+
+// Stop stops the client. It can be started again.
+func (c *MessagingClient) Stop() error { return liblogosdelivery.Stop(c.h) }
+
+// Close stops tracking events and releases the underlying node context. The
+// Events channel is closed. The MessagingClient must not be used afterwards.
+func (c *MessagingClient) Close() error {
+	err := liblogosdelivery.Destroy(c.h)
+	c.closeOnce.Do(func() { close(c.events) })
+	return err
+}
+
+// Subscribe subscribes to a content topic so messages on it are received.
+func (c *MessagingClient) Subscribe(topic ContentTopic) error {
+	return liblogosdelivery.Subscribe(c.h, topic)
+}
+
+// Unsubscribe stops receiving messages on a content topic.
+func (c *MessagingClient) Unsubscribe(topic ContentTopic) error {
+	return liblogosdelivery.Unsubscribe(c.h, topic)
+}
+
+// Send publishes env and returns the RequestID to correlate with the later
+// MessageSentEvent / MessagePropagatedEvent / MessageErrorEvent. The send is
+// fire-and-queue: ctx cancellation is honoured before dispatch only.
+func (c *MessagingClient) Send(ctx context.Context, env Envelope) (RequestID, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	msg, err := json.Marshal(struct {
+		ContentTopic string `json:"contentTopic"`
+		Payload      string `json:"payload"`
+		Ephemeral    bool   `json:"ephemeral"`
+	}{
+		ContentTopic: string(env.ContentTopic),
+		Payload:      base64.StdEncoding.EncodeToString(env.Payload),
+		Ephemeral:    env.Ephemeral,
+	})
+	if err != nil {
+		return "", fmt.Errorf("marshal envelope: %w", err)
+	}
+	id, err := liblogosdelivery.Send(c.h, string(msg))
+	if err != nil {
+		return "", err
+	}
+	return RequestID(id), nil
+}
+
+// Events returns the channel of incoming Messaging API events. Type-switch over
+// the concrete Event types. The channel is closed by Close.
+func (c *MessagingClient) Events() <-chan Event { return c.events }


### PR DESCRIPTION
Iterates #106

Requires and based on:
- https://github.com/logos-messaging/logos-delivery-go-bindings/pull/113

## What
The idiomatic Go Messaging API mirroring the Nim `MessagingClient`, built on the `internal/ffi` liblogosdelivery bridge from #113.

- **`Node`** — `NewNode`/`Start`/`Stop`/`Close`, `Subscribe`/`Unsubscribe`, `Send(ctx, Envelope) → RequestID`.
- **Unified `Events() <-chan Event`** with a sealed `Event` interface (`MessageReceived`/`Sent`/`Propagated`/`Error`, `ConnectionStatus`). Events are dropped (never block) if a consumer falls behind.
- **Event decoding** matches liblogosdelivery's std/json wire format: received `payload`/`meta` arrive as **JSON byte-int arrays, not base64** (with base64/null fallbacks); `connectionStatus` is an enum-name string. Unit-tested.
- **`Config`** aliases the kernel `WakuNodeConf`.
- **`examples/messaging`** — runnable demo.

## Verified locally
`go build ./...`, `go test ./pkg/messaging/...` (decode tests pass), `golangci-lint` (0 issues) on top of #113.

## Out of scope (after logos-delivery#3851)
Store + generic kernel accessors on the same `Node`.